### PR TITLE
AB#204 - View investments in a portfolio

### DIFF
--- a/.changeset/fast-eagles-follow.md
+++ b/.changeset/fast-eagles-follow.md
@@ -1,0 +1,8 @@
+---
+"@stratify/stratify-api": patch
+---
+
+- Build endpoint to retrieve the investments in a portfolio
+- Add unit tests for the endpoint
+- Add migration to change the primary key for the trades table to an auto-incrementing number instead of a composite key made up of the asset symbol, trade date and portfolio id
+- Add column to store the total amount of a trade in the currency of the asset in the trades table

--- a/.changeset/loose-chicken-melt.md
+++ b/.changeset/loose-chicken-melt.md
@@ -5,3 +5,4 @@
 - Build data table to display the investments in a portfolio
 - Add unit tests for the investments table
 - Improve data table with pagination
+- Set selected portfolio to the first portfolio in the list when the user navigates to the portfolios page

--- a/.changeset/loose-chicken-melt.md
+++ b/.changeset/loose-chicken-melt.md
@@ -1,0 +1,7 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+- Build data table to display the investments in a portfolio
+- Add unit tests for the investments table
+- Improve data table with pagination

--- a/.changeset/warm-canyons-eat.md
+++ b/.changeset/warm-canyons-eat.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-data-api": patch
+---
+
+Update openapi spec

--- a/apps/api/stratify-api/docs/Stratify API/portfolios/Investments in a portfolio.bru
+++ b/apps/api/stratify-api/docs/Stratify API/portfolios/Investments in a portfolio.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Investments in a portfolio
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/portfolios/:portfolioId/investments
+  body: none
+  auth: inherit
+}
+
+params:path {
+  portfolioId: 1
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/apps/api/stratify-api/src/database/migrations/2026021316425_add_asset_currency_total_column.ts
+++ b/apps/api/stratify-api/src/database/migrations/2026021316425_add_asset_currency_total_column.ts
@@ -1,0 +1,17 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .addColumn("asset_currency_total_amount", "numeric")
+        .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .dropColumn("asset_currency_total_amount")
+        .execute();
+}

--- a/apps/api/stratify-api/src/database/migrations/2026021322141_change_trades_primary_key.ts
+++ b/apps/api/stratify-api/src/database/migrations/2026021322141_change_trades_primary_key.ts
@@ -1,0 +1,45 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .dropConstraint("trades_pkey")
+        .execute();
+
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .addColumn("id", "serial", (col) => col.notNull())
+        .execute();
+
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .addPrimaryKeyConstraint("trades_pkey", ["id"])
+        .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .dropConstraint("trades_pkey")
+        .execute();
+
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .dropColumn("id")
+        .execute();
+
+    await db.schema
+        .withSchema("stratify")
+        .alterTable("trades")
+        .addPrimaryKeyConstraint("trades_pkey", [
+            "asset_id",
+            "portfolio_id",
+            "trade_date",
+        ])
+        .execute();
+}

--- a/apps/api/stratify-api/src/database/types.ts
+++ b/apps/api/stratify-api/src/database/types.ts
@@ -134,6 +134,7 @@ export interface StratifyTrades {
   assetId: string;
   createdAt: Generated<Timestamp>;
   fee: Numeric | null;
+  id: Generated<number>;
   portfolioId: Generated<number>;
   pricePerShare: Numeric;
   quantity: Numeric;

--- a/apps/api/stratify-api/src/database/types.ts
+++ b/apps/api/stratify-api/src/database/types.ts
@@ -130,6 +130,7 @@ export interface StratifyPortfolios {
 
 export interface StratifyTrades {
   assetCountryId: number;
+  assetCurrencyTotalAmount: Numeric | null;
   assetId: string;
   createdAt: Generated<Timestamp>;
   fee: Numeric | null;

--- a/apps/api/stratify-api/src/routes/assets/fetch-asset-price.ts
+++ b/apps/api/stratify-api/src/routes/assets/fetch-asset-price.ts
@@ -1,0 +1,32 @@
+import { dataApiClient } from "../../lib/api/data-api-client.js";
+import logger from "../../logger.js";
+
+export const fetchAssetPrice = async (
+    assetSymbol: string,
+    assetCountryId: number,
+) => {
+    // Append .L for London Stock Exchange assets (UK assets)
+    const symbol = assetCountryId === 223 ? `${assetSymbol}-L` : assetSymbol;
+
+    try {
+        const response = await dataApiClient()
+            .GET("/assets/{symbol}/current-price", {
+                params: {
+                    path: {
+                        symbol,
+                    },
+                },
+            })
+            .then((res) => res.data?.data);
+
+        return response;
+    } catch (error) {
+        logger.error(
+            {
+                error,
+                symbol,
+            },
+            "Error fetching asset price for symbol",
+        );
+    }
+};

--- a/apps/api/stratify-api/src/routes/assets/search.post.ts
+++ b/apps/api/stratify-api/src/routes/assets/search.post.ts
@@ -2,7 +2,6 @@ import { FastifyInstance } from "fastify";
 import logger from "../../logger.js";
 import db from "../../database/db.js";
 import { InferResult, sql } from "kysely";
-import { dataApiClient } from "../../lib/api/data-api-client.js";
 import {
     BadRequestResponse,
     badRequestSchema,
@@ -14,6 +13,7 @@ import {
     SearchAssetsSuccessResponse,
 } from "./search-schemas.js";
 import { formatSearchAsset } from "./formatSearchAsset.js";
+import { fetchAssetPrice } from "./fetch-asset-price.js";
 
 const assetsSearchQuery = (query: string) => {
     return db
@@ -43,40 +43,16 @@ export type DbSearchAsset = InferResult<
     ReturnType<typeof assetsSearchQuery>
 >[number];
 
-const fetchAssetPrice = async (asset: DbSearchAsset) => {
-    // Append .L for London Stock Exchange assets (UK assets)
-    const symbol = asset.countryId === 223 ? `${asset.symbol}-L` : asset.symbol;
-
-    try {
-        const response = await dataApiClient()
-            .GET("/assets/{symbol}/current-price", {
-                params: {
-                    path: {
-                        symbol,
-                    },
-                },
-            })
-            .then((res) => res.data?.data);
-
-        return response;
-    } catch (error) {
-        logger.error(
-            {
-                error,
-                symbol,
-            },
-            "Error fetching asset price for symbol",
-        );
-    }
-};
-
 const searchAssets = async (query: string) => {
     try {
         const assetsFromDb = await assetsSearchQuery(query).execute();
 
         const formattedAssets = await Promise.all(
             assetsFromDb.map(async (asset) => {
-                const currentPriceData = await fetchAssetPrice(asset);
+                const currentPriceData = await fetchAssetPrice(
+                    asset.symbol,
+                    asset.countryId,
+                );
 
                 return formatSearchAsset(asset, currentPriceData);
             }),

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.test.ts
@@ -147,6 +147,7 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                 {
                     symbol: "LEON",
                     assetCountryId: 224,
+                    assetCurrency: "USD",
                     name: "Leonida Inc.",
                     shares: 20,
                     type: "STOCK",
@@ -158,6 +159,7 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                 {
                     symbol: "AAPL",
                     assetCountryId: 224,
+                    assetCurrency: "USD",
                     name: "Apple Inc.",
                     shares: 15,
                     type: "STOCK",
@@ -258,6 +260,7 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                 {
                     symbol: "BRIT",
                     assetCountryId: 223,
+                    assetCurrency: "GBP",
                     name: "British Company",
                     shares: 15,
                     type: "STOCK",
@@ -269,6 +272,7 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                 {
                     symbol: "CHEESE",
                     assetCountryId: 223,
+                    assetCurrency: "GBP",
                     name: "Cheese Company",
                     shares: 5,
                     type: "STOCK",
@@ -359,6 +363,7 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                 {
                     symbol: "BRIT",
                     assetCountryId: 223,
+                    assetCurrency: "GBP",
                     name: "British Company",
                     shares: 10,
                     type: "STOCK",

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import loadMockApp from "../../../__mocks__/mockApp.js";
+import db from "../../../database/db.js";
+import { createUser } from "../../../tests/create-user.js";
+
+const mockAssetPriceResponse = {
+    data: {
+        data: {
+            currentPrice: 152,
+            change: 2.5,
+            changePercent: 1.69,
+        },
+    },
+};
+
+const mockGetCurrentPrice = vi.fn();
+
+const mockDataApiClient = {
+    GET: mockGetCurrentPrice,
+};
+
+vi.mock("../../../lib/api/data-api-client", () => ({
+    dataApiClient: () => mockDataApiClient,
+}));
+
+describe("GET /portfolios/:portfolioId/investments", () => {
+    const devToken =
+        "Bearer Dev-eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3NjkwMzQ3NTgsIm5hbWUiOiJ0ZXN0LXVzZXIiLCJlbWFpbCI6InRlc3QtdXNlckB0ZXN0LmNvbSIsImVtYWlsVmVyaWZpZWQiOmZhbHNlLCJpbWFnZSI6bnVsbCwiY3JlYXRlZEF0IjoiMjAyNi0wMS0yMVQyMDo1MjoxMC45MTFaIiwidXBkYXRlZEF0IjoiMjAyNi0wMS0yMVQyMDo1MjoxMC45MTFaIiwidXNlcm5hbWUiOiJ0ZXN0LXVzZXIiLCJkaXNwbGF5VXNlcm5hbWUiOiJ0ZXN0LXVzZXIiLCJ0d29GYWN0b3JFbmFibGVkIjpmYWxzZSwiaWQiOiJ0ZXN0LXVzZXIiLCJzdWIiOiJ0ZXN0LXVzZXIiLCJleHAiOjE3NjkwMzgzNTgsImlzcyI6Imh0dHA6Ly8xMjcuMC4wLjE6MjAwMCIsImF1ZCI6Imh0dHA6Ly8xMjcuMC4wLjE6MjAwMCJ9.4h0c9ETlknvzcvHhQULDfCx5OF0_nlo-S_j0BbXqrdQbkzigNUqeU2E3EC-2YeSBMwJk6ERGar_LJ-sBAtK9DQ";
+
+    const secondDevToken =
+        "Bearer Dev-eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3NjkwMzQ3NTgsIm5hbWUiOiJhbm90aGVyLXRlc3QtdXNlciIsImVtYWlsIjoiYW5vdGhlci10ZXN0LXVzZXJAdGVzdC5jb20iLCJlbWFpbFZlcmlmaWVkIjpmYWxzZSwiaW1hZ2UiOm51bGwsImNyZWF0ZWRBdCI6IjIwMjYtMDEtMjFUMjA6NTI6MTAuOTExWiIsInVwZGF0ZWRBdCI6IjIwMjYtMDEtMjFUMjA6NTI6MTAuOTExWiIsInVzZXJuYW1lIjoiYW5vdGhlci10ZXN0LXVzZXIiLCJkaXNwbGF5VXNlcm5hbWUiOiJhbm90aGVyLXRlc3QtdXNlciIsInR3b0ZhY3RvckVuYWJsZWQiOmZhbHNlLCJpZCI6ImFub3RoZXItdGVzdC11c2VyIiwic3ViIjoiYW5vdGhlci10ZXN0LXVzZXIiLCJleHAiOjE3NjkwMzgzNTgsImlzcyI6Imh0dHA6Ly8xMjcuMC4wLjE6MjAwMCIsImF1ZCI6Imh0dHA6Ly8xMjcuMC4wLjE6MjAwMCJ9.loa5vJNiu9uwpmSTilPMCDI4NF2e0GP6ATO7fmQNuRjg-ByCgmJTcAUd-jNY4A2Lkls_VTED07WYEe8SelVRCA";
+
+    let app: any;
+
+    beforeAll(async () => {
+        app = await loadMockApp();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("should return a list of investments for a portfolio successfully", async () => {
+        mockGetCurrentPrice.mockResolvedValue(mockAssetPriceResponse);
+
+        await createUser("test-user").execute();
+
+        await db
+            .insertInto("stratify.assets")
+            .values([
+                {
+                    name: "Apple Inc.",
+                    symbol: "AAPL",
+                    currency: "USD",
+                    type: "STOCK",
+                    countryId: 224, // Country ID for united states
+                },
+                {
+                    name: "Leonida Inc.",
+                    symbol: "LEON",
+                    currency: "USD",
+                    type: "STOCK",
+                    countryId: 224, // Country ID for united states
+                },
+            ])
+            .execute();
+
+        await db
+            .insertInto("stratify.assetPrices")
+            .values([
+                {
+                    assetId: "USDGBP",
+                    countryId: 224,
+                    priceDate: new Date(),
+                    lowPrice: 0.75,
+                    highPrice: 0.77,
+                    openPrice: 0.76,
+                    closePrice: 0.73,
+                    volume: 0,
+                },
+            ])
+            .execute();
+
+        const portfolio = await db
+            .insertInto("stratify.portfolios")
+            .values({
+                name: "Test Portfolio",
+                userId: "test-user",
+            })
+            .returning("stratify.portfolios.id as id")
+            .executeTakeFirstOrThrow();
+
+        await db
+            .insertInto("stratify.trades")
+            .values([
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "AAPL",
+                    assetCountryId: 224,
+                    quantity: 5,
+                    pricePerShare: 150,
+                    totalAmount: 750,
+                    assetCurrencyTotalAmount: 800,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-02"),
+                },
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "AAPL",
+                    assetCountryId: 224,
+                    quantity: 10,
+                    pricePerShare: 150,
+                    totalAmount: 1500,
+                    assetCurrencyTotalAmount: 1600,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-03"),
+                },
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "LEON",
+                    assetCountryId: 224,
+                    quantity: 20,
+                    pricePerShare: 50,
+                    totalAmount: 1000,
+                    assetCurrencyTotalAmount: 1100,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-04"),
+                },
+            ])
+            .execute();
+
+        const response = await app.inject({
+            method: "GET",
+            url: `/portfolios/${portfolio.id}/investments`,
+            headers: {
+                Authorization: devToken,
+                Accept: "application/json",
+            },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const json = await response.json();
+
+        expect(json).toEqual({
+            data: [
+                {
+                    symbol: "LEON",
+                    assetCountryId: 224,
+                    name: "Leonida Inc.",
+                    shares: 20,
+                    type: "STOCK",
+                    currentValue: 2219.2,
+                    currentAssetCurrencyValue: 3040,
+                    currentReturn: 1489.2,
+                    currentReturnPercentage: 204,
+                },
+                {
+                    symbol: "AAPL",
+                    assetCountryId: 224,
+                    name: "Apple Inc.",
+                    shares: 15,
+                    type: "STOCK",
+                    currentValue: 1664.4,
+                    currentAssetCurrencyValue: 2280,
+                    currentReturn: 21.9,
+                    currentReturnPercentage: 1.33,
+                },
+            ],
+        });
+    });
+
+    it("should return a list of investments where the asset currency is the same as the user's currency without performing currency conversion", async () => {
+        mockGetCurrentPrice.mockResolvedValue(mockAssetPriceResponse);
+
+        await createUser("test-user").execute();
+
+        await db
+            .insertInto("stratify.assets")
+            .values([
+                {
+                    name: "British Company",
+                    symbol: "BRIT",
+                    currency: "GBP",
+                    type: "STOCK",
+                    countryId: 223, // Country ID for united states
+                },
+                {
+                    name: "Cheese Company",
+                    symbol: "CHEESE",
+                    currency: "GBP",
+                    type: "STOCK",
+                    countryId: 223, // Country ID for united states
+                },
+            ])
+            .execute();
+
+        const portfolio = await db
+            .insertInto("stratify.portfolios")
+            .values({
+                name: "British Stocks",
+                userId: "test-user",
+            })
+            .returning("stratify.portfolios.id as id")
+            .executeTakeFirstOrThrow();
+
+        await db
+            .insertInto("stratify.trades")
+            .values([
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "BRIT",
+                    assetCountryId: 223,
+                    quantity: 5,
+                    pricePerShare: 150,
+                    totalAmount: 750,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-02"),
+                },
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "BRIT",
+                    assetCountryId: 223,
+                    quantity: 10,
+                    pricePerShare: 150,
+                    totalAmount: 1500,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-03"),
+                },
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "CHEESE",
+                    assetCountryId: 223,
+                    quantity: 5,
+                    pricePerShare: 100,
+                    totalAmount: 500,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-05"),
+                },
+            ])
+            .execute();
+
+        const response = await app.inject({
+            method: "GET",
+            url: `/portfolios/${portfolio.id}/investments`,
+            headers: {
+                Authorization: devToken,
+                Accept: "application/json",
+            },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const json = await response.json();
+
+        expect(json).toEqual({
+            data: [
+                {
+                    symbol: "BRIT",
+                    assetCountryId: 223,
+                    name: "British Company",
+                    shares: 15,
+                    type: "STOCK",
+                    currentValue: 2280,
+                    currentAssetCurrencyValue: null,
+                    currentReturn: 30,
+                    currentReturnPercentage: 1.33,
+                },
+                {
+                    symbol: "CHEESE",
+                    assetCountryId: 223,
+                    name: "Cheese Company",
+                    shares: 5,
+                    type: "STOCK",
+                    currentValue: 760,
+                    currentAssetCurrencyValue: null,
+                    currentReturn: 260,
+                    currentReturnPercentage: 52,
+                },
+            ],
+        });
+    });
+
+    it("should not count SELL trades towards the total shares and returns of an investment", async () => {
+        mockGetCurrentPrice.mockResolvedValue(mockAssetPriceResponse);
+
+        await createUser("test-user").execute();
+
+        await db
+            .insertInto("stratify.assets")
+            .values([
+                {
+                    name: "British Company",
+                    symbol: "BRIT",
+                    currency: "GBP",
+                    type: "STOCK",
+                    countryId: 223, // Country ID for united states
+                },
+                {
+                    name: "Cheese Company",
+                    symbol: "CHEESE",
+                    currency: "GBP",
+                    type: "STOCK",
+                    countryId: 223, // Country ID for united states
+                },
+            ])
+            .execute();
+
+        const portfolio = await db
+            .insertInto("stratify.portfolios")
+            .values({
+                name: "British Stocks",
+                userId: "test-user",
+            })
+            .returning("stratify.portfolios.id as id")
+            .executeTakeFirstOrThrow();
+
+        await db
+            .insertInto("stratify.trades")
+            .values([
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "BRIT",
+                    assetCountryId: 223,
+                    quantity: 15,
+                    pricePerShare: 150,
+                    totalAmount: 2250,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-02"),
+                },
+                {
+                    portfolioId: portfolio.id,
+                    assetId: "BRIT",
+                    assetCountryId: 223,
+                    quantity: 5,
+                    pricePerShare: 170,
+                    totalAmount: 850,
+                    tradeAction: "SELL",
+                    tradeDate: new Date("2026-02-03"),
+                },
+            ])
+            .execute();
+
+        const response = await app.inject({
+            method: "GET",
+            url: `/portfolios/${portfolio.id}/investments`,
+            headers: {
+                Authorization: devToken,
+                Accept: "application/json",
+            },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const json = await response.json();
+
+        expect(json).toEqual({
+            data: [
+                {
+                    symbol: "BRIT",
+                    assetCountryId: 223,
+                    name: "British Company",
+                    shares: 10,
+                    type: "STOCK",
+                    currentValue: 1520,
+                    currentAssetCurrencyValue: null,
+                    currentReturn: 120,
+                    currentReturnPercentage: 8.57,
+                },
+            ],
+        });
+    });
+
+    it("should return a 404 error if there are no investments in the portfolio", async () => {
+        await createUser("test-user").execute();
+
+        const portfolio = await db
+            .insertInto("stratify.portfolios")
+            .values({
+                name: "Empty Portfolio",
+                userId: "test-user",
+            })
+            .returning("stratify.portfolios.id as id")
+            .executeTakeFirstOrThrow();
+
+        const response = await app.inject({
+            method: "GET",
+            url: `/portfolios/${portfolio.id}/investments`,
+            headers: {
+                Authorization: devToken,
+                Accept: "application/json",
+            },
+        });
+
+        expect(response.statusCode).toBe(404);
+
+        const json = await response.json();
+
+        expect(json).toEqual({
+            message: "investmentsNotFound",
+        });
+    });
+
+    it("should return a 404 error if portfolio doesn't exist", async () => {
+        await createUser("test-user").execute();
+
+        const response = await app.inject({
+            method: "GET",
+            url: `/portfolios/9999/investments`,
+            headers: {
+                Authorization: devToken,
+                Accept: "application/json",
+            },
+        });
+
+        expect(response.statusCode).toBe(404);
+    });
+
+    it("should not allow a user to get the investments of another user's portfolio", async () => {
+        mockGetCurrentPrice.mockResolvedValue(mockAssetPriceResponse);
+
+        await createUser("test-user").execute();
+        await createUser("another-test-user").execute();
+
+        await db
+            .insertInto("stratify.assets")
+            .values({
+                name: "Apple Inc.",
+                symbol: "AAPL",
+                currency: "USD",
+                type: "STOCK",
+                countryId: 224, // Country ID for united states
+            })
+            .execute();
+
+        await db
+            .insertInto("stratify.assetPrices")
+            .values([
+                {
+                    assetId: "USDGBP",
+                    countryId: 224,
+                    priceDate: new Date(),
+                    lowPrice: 0.75,
+                    highPrice: 0.77,
+                    openPrice: 0.76,
+                    closePrice: 0.73,
+                    volume: 0,
+                },
+            ])
+            .execute();
+
+        const portfolio = await db
+            .insertInto("stratify.portfolios")
+            .values({
+                name: "Another User's Portfolio",
+                userId: "test-user",
+            })
+            .returning("stratify.portfolios.id as id")
+            .executeTakeFirstOrThrow();
+
+        const response = await app.inject({
+            method: "GET",
+            url: `/portfolios/${portfolio.id}/investments`,
+            headers: {
+                Authorization: secondDevToken,
+                Accept: "application/json",
+            },
+        });
+
+        expect(response.statusCode).toBe(404);
+    });
+});

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.ts
@@ -1,0 +1,209 @@
+import { FastifyInstance } from "fastify";
+import logger from "../../../logger.js";
+import { getFromStore } from "../../../plugins/localStorage.js";
+import { UserDetails } from "../../../utils/decodeToken.js";
+import {
+    InvestmentsNotFound,
+    investmentsNotFoundSchema,
+    InvestmentsResponse,
+    investmentsResponseSchema,
+    PortfolioIdParam,
+    portfolioIdParamSchema,
+} from "./investments.schema.js";
+import db from "../../../database/db.js";
+import { InferResult } from "kysely";
+import { fetchAssetPrice } from "../../assets/fetch-asset-price.js";
+import { formatInvestmentDetails } from "./format-investment-details.js";
+
+const portfolioInvestmentsQuery = (portfolioId: number, userId: string) =>
+    db
+        .selectFrom("stratify.trades as trades")
+        .innerJoin(
+            "stratify.portfolios as portfolios",
+            "trades.portfolioId",
+            "portfolios.id",
+        )
+        .where("portfolios.id", "=", portfolioId)
+        .where("portfolios.userId", "=", userId)
+        .select([
+            "trades.id as tradeId",
+            "trades.tradeDate as tradeDate",
+            "trades.quantity as quantity",
+            "trades.pricePerShare as pricePerShare",
+            "trades.tradeAction as tradeAction",
+            "trades.totalAmount as totalAmount",
+            "trades.assetCurrencyTotalAmount as assetCurrencyTotalAmount",
+            "trades.assetId as assetId",
+            "trades.assetCountryId as assetCountryId",
+        ])
+        //? Order by trade date from oldest to newest
+        .orderBy("trades.tradeDate", "asc");
+
+const assetDetailsQuery = (assetId: string, countryId: number) =>
+    db
+        .selectFrom("stratify.assets as assets")
+        .where("assets.symbol", "=", assetId)
+        .where("assets.countryId", "=", countryId)
+        .select([
+            "assets.name as name",
+            "assets.type as type",
+            "assets.currency as assetCurrency",
+        ]);
+
+export type AssetDetails = InferResult<
+    ReturnType<typeof assetDetailsQuery>
+>[number];
+
+export interface GroupedInvestment {
+    id: string;
+    symbol: string;
+    assetCountryId: number;
+    shares: number;
+    totalPurchaseValue: number;
+}
+
+const retrieveInvestments = async (
+    portfolioId: number,
+    userId: string,
+    userCurrency: string,
+) => {
+    const trades = await portfolioInvestmentsQuery(
+        portfolioId,
+        userId,
+    ).execute();
+
+    if (trades.length === 0) {
+        return [];
+    }
+
+    // TODO: Add calculation of realised gains/losses for sold shares, only unrealised returns for currently held shares are calculated
+    const groupedInvestmentsMap = trades.reduce((acc, trade) => {
+        //? A composite key here is required to group assets by symbol and country
+        const key = `${trade.assetId}-${trade.assetCountryId}`;
+
+        if (acc.has(key)) {
+            return acc;
+        }
+
+        const tradesForAsset = trades.filter(
+            (t) =>
+                t.assetCountryId === trade.assetCountryId &&
+                t.assetId === trade.assetId,
+        );
+
+        //? How many shares of this asset are currently held?
+        const currentHoldingQuantity = tradesForAsset.reduce((sum, t) => {
+            const quantity = parseFloat(t.quantity);
+            return t.tradeAction === "BUY" ? sum + quantity : sum - quantity;
+        }, 0);
+
+        //? What is the total cost for the currently held shares of this asset (in the user's currency)?
+        const totalPurchaseValue = tradesForAsset.reduce((sum, t) => {
+            const tradeAmount = parseFloat(t.totalAmount);
+
+            return t.tradeAction === "BUY"
+                ? sum + tradeAmount
+                : sum - tradeAmount;
+        }, 0);
+
+        //? Only return the asset if the user is holding shares of it. If the quantity currently held is 0, then the investment has been fully sold
+        if (currentHoldingQuantity > 0) {
+            acc.set(key, {
+                id: key,
+                symbol: trade.assetId,
+                assetCountryId: trade.assetCountryId,
+                shares: currentHoldingQuantity,
+                totalPurchaseValue,
+            });
+        }
+
+        return acc;
+    }, new Map<string, GroupedInvestment>());
+
+    const groupedInvestments = Array.from(groupedInvestmentsMap.values());
+
+    const formattedInvestments = await Promise.all(
+        groupedInvestments.map(async (investment) => {
+            const [symbol, countryId] = investment.id.split("-");
+
+            const assetCountryId = parseInt(countryId);
+
+            const assetDetails = await assetDetailsQuery(
+                symbol,
+                assetCountryId,
+            ).executeTakeFirstOrThrow();
+
+            //? Get the current value of the asset and multiply it by the number of shares held to get the overall investment value
+            //? The current price of the asset is in the asset's currency so it needs to be converted to the user's currency if they are different
+            const currentInvestmentValue = await fetchAssetPrice(
+                symbol,
+                assetCountryId,
+            ).then((priceDetails) => {
+                const price = priceDetails?.currentPrice ?? 0;
+                return price * investment.shares;
+            });
+
+            //? Format the details of the investment, convert the monetary amounts by currency if needed and return it
+            return await formatInvestmentDetails(
+                investment,
+                assetDetails,
+                currentInvestmentValue,
+                userCurrency,
+            );
+        }),
+    );
+
+    //? Sort investments by highest current value first
+    return formattedInvestments.sort((a, b) => b.currentValue - a.currentValue);
+};
+
+export default async function portfolioInvestmentsGet(
+    fastify: FastifyInstance,
+) {
+    fastify.route<{
+        Params: PortfolioIdParam;
+        Reply: InvestmentsResponse | InvestmentsNotFound;
+    }>({
+        method: "GET",
+        url: "/portfolios/:portfolioId/investments",
+        schema: {
+            params: portfolioIdParamSchema,
+            response: {
+                200: investmentsResponseSchema,
+                404: investmentsNotFoundSchema,
+            },
+        },
+        handler: async (request, reply) => {
+            try {
+                const { portfolioId } = request.params;
+
+                const { userId, defaultCurrency } = getFromStore(
+                    "user",
+                ) as UserDetails;
+
+                const investments = await retrieveInvestments(
+                    portfolioId,
+                    userId,
+                    defaultCurrency,
+                );
+
+                if (investments.length === 0) {
+                    return reply.status(404).send({
+                        message: "investmentsNotFound",
+                    });
+                }
+
+                return reply.status(200).send({
+                    data: investments,
+                });
+            } catch (error) {
+                logger.error(
+                    { error },
+                    "Error fetching investments for portfolio",
+                );
+
+                throw error;
+            }
+        },
+    });
+}

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.ts
@@ -3,6 +3,7 @@ import logger from "../../../logger.js";
 import { getFromStore } from "../../../plugins/localStorage.js";
 import { UserDetails } from "../../../utils/decodeToken.js";
 import {
+    Investment,
     InvestmentsNotFound,
     investmentsNotFoundSchema,
     InvestmentsResponse,
@@ -157,6 +158,131 @@ const retrieveInvestments = async (
     return formattedInvestments.sort((a, b) => b.currentValue - a.currentValue);
 };
 
+const retrieveMockedInvestments = () => {
+    return [
+        {
+            symbol: "LEON",
+            assetCountryId: 223,
+            name: "Leonida Inc.",
+            assetCurrency: "GBP",
+            shares: 20,
+            type: "STOCK",
+            currentValue: 2219.2,
+            currentAssetCurrencyValue: null,
+            currentReturn: 1489.2,
+            currentReturnPercentage: 204,
+        },
+        {
+            symbol: "AAPL",
+            assetCountryId: 224,
+            name: "Apple Inc.",
+            assetCurrency: "USD",
+            shares: 15,
+            type: "STOCK",
+            currentValue: 1664.4,
+            currentAssetCurrencyValue: 2280,
+            currentReturn: 21.9,
+            currentReturnPercentage: 1.33,
+        },
+        {
+            symbol: "TSLA",
+            assetCountryId: 224,
+            name: "Tesla Inc.",
+            assetCurrency: "USD",
+            shares: 10,
+            type: "STOCK",
+            currentValue: 791.2,
+            currentAssetCurrencyValue: 1200,
+            currentReturn: -208.8,
+            currentReturnPercentage: -20.9,
+        },
+        {
+            symbol: "AMZN",
+            assetCountryId: 224,
+            assetCurrency: "USD",
+            name: "Amazon.com Inc.",
+            shares: 5,
+            type: "STOCK",
+            currentValue: 1500,
+            currentAssetCurrencyValue: 1500,
+            currentReturn: 500,
+            currentReturnPercentage: 50,
+        },
+        {
+            symbol: "GOOGL",
+            assetCountryId: 224,
+            assetCurrency: "USD",
+            name: "Alphabet Inc.",
+            shares: 8,
+            type: "STOCK",
+            currentValue: 2000,
+            currentAssetCurrencyValue: 2000,
+            currentReturn: 1000,
+            currentReturnPercentage: 100,
+        },
+        {
+            symbol: "NFLX",
+            assetCountryId: 224,
+            assetCurrency: "USD",
+            name: "Netflix Inc.",
+            shares: 12,
+            type: "STOCK",
+            currentValue: 1200,
+            currentAssetCurrencyValue: 1200,
+            currentReturn: -300,
+            currentReturnPercentage: -20,
+        },
+        {
+            symbol: "MSFT",
+            assetCountryId: 224,
+            assetCurrency: "USD",
+            name: "Microsoft Corporation",
+            shares: 18,
+            type: "STOCK",
+            currentValue: 2700,
+            currentAssetCurrencyValue: 2700,
+            currentReturn: 900,
+            currentReturnPercentage: 50,
+        },
+        {
+            symbol: "META",
+            assetCountryId: 224,
+            assetCurrency: "USD",
+            name: "Meta Platforms Inc.",
+            shares: 7,
+            type: "STOCK",
+            currentValue: 1400,
+            currentAssetCurrencyValue: 1400,
+            currentReturn: -100,
+            currentReturnPercentage: -6.67,
+        },
+        {
+            symbol: "NVDA",
+            assetCountryId: 224,
+            assetCurrency: "USD",
+            name: "NVIDIA Corporation",
+            shares: 9,
+            type: "STOCK",
+            currentValue: 1800,
+            currentAssetCurrencyValue: 1800,
+            currentReturn: 600,
+            currentReturnPercentage: 50,
+        },
+        {
+            symbol: "ADBE",
+            assetCountryId: 224,
+            assetCurrency: "USD",
+            name: "Adobe Inc.",
+            shares: 6,
+            type: "STOCK",
+            currentValue: 1500,
+            currentAssetCurrencyValue: 1500,
+            currentReturn: 300,
+            currentReturnPercentage: 25,
+        },
+    ] satisfies Investment[];
+};
+
 export default async function portfolioInvestmentsGet(
     fastify: FastifyInstance,
 ) {
@@ -180,6 +306,10 @@ export default async function portfolioInvestmentsGet(
                 const { userId, defaultCurrency } = getFromStore(
                     "user",
                 ) as UserDetails;
+
+                return reply.status(200).send({
+                    data: retrieveMockedInvestments(),
+                });
 
                 const investments = await retrieveInvestments(
                     portfolioId,

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/[portfolioId].investments.get.ts
@@ -307,10 +307,6 @@ export default async function portfolioInvestmentsGet(
                     "user",
                 ) as UserDetails;
 
-                return reply.status(200).send({
-                    data: retrieveMockedInvestments(),
-                });
-
                 const investments = await retrieveInvestments(
                     portfolioId,
                     userId,

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/format-investment-details.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/format-investment-details.ts
@@ -1,0 +1,60 @@
+import { AssetType } from "../../../schemas/common-schemas.js";
+import { currencyConversionRateQuery } from "../../../utils/currency-conversion-rate-query.js";
+import {
+    AssetDetails,
+    GroupedInvestment,
+} from "./[portfolioId].investments.get.js";
+import { Investment } from "./investments.schema.js";
+
+export const formatInvestmentDetails = async (
+    investment: GroupedInvestment,
+    assetDetails: AssetDetails,
+    currentInvestmentValue: number,
+    userCurrency: string | null,
+) => {
+    const { name, type, assetCurrency } = assetDetails;
+    const { symbol, assetCountryId, shares, totalPurchaseValue } = investment;
+
+    const currentReturn = currentInvestmentValue - totalPurchaseValue;
+
+    const isCurrencyConversionRequired =
+        assetCurrency && userCurrency !== assetCurrency ? true : false;
+
+    let conversionRate = 1;
+
+    //? If the asset currency is different to the user's currency, then the current value and investment return need to be converted
+    if (isCurrencyConversionRequired && assetCurrency && userCurrency) {
+        const { price } = await currencyConversionRateQuery(
+            assetCurrency,
+            userCurrency,
+            new Date(),
+        ).executeTakeFirstOrThrow();
+
+        conversionRate = parseFloat(price);
+    }
+
+    const currentReturnPercentage =
+        totalPurchaseValue > 0
+            ? parseFloat(
+                  ((currentReturn / totalPurchaseValue) * 100).toFixed(2),
+              )
+            : 0;
+
+    return {
+        symbol,
+        assetCountryId,
+        name,
+        shares,
+        type: type as AssetType,
+        currentValue: isCurrencyConversionRequired
+            ? parseFloat((currentInvestmentValue * conversionRate).toFixed(2))
+            : parseFloat(currentInvestmentValue.toFixed(2)),
+        currentAssetCurrencyValue: isCurrencyConversionRequired
+            ? parseFloat(currentInvestmentValue.toFixed(2))
+            : null,
+        currentReturn: isCurrencyConversionRequired
+            ? parseFloat((currentReturn * conversionRate).toFixed(2))
+            : parseFloat(currentReturn.toFixed(2)),
+        currentReturnPercentage,
+    } satisfies Investment;
+};

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/format-investment-details.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/format-investment-details.ts
@@ -44,8 +44,9 @@ export const formatInvestmentDetails = async (
         symbol,
         assetCountryId,
         name,
-        shares,
         type: type as AssetType,
+        assetCurrency,
+        shares,
         currentValue: isCurrencyConversionRequired
             ? parseFloat((currentInvestmentValue * conversionRate).toFixed(2))
             : parseFloat(currentInvestmentValue.toFixed(2)),

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments.schema.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments.schema.ts
@@ -12,6 +12,7 @@ export const investmentSchema = Type.Object({
     assetCountryId: Type.Number(),
     name: Type.String(),
     type: assetTypeSchema,
+    assetCurrency: Type.Union([Type.String(), Type.Null()]),
     shares: Type.Number(),
     currentValue: Type.Number(),
     currentAssetCurrencyValue: Type.Union([Type.Number(), Type.Null()]),

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments.schema.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments.schema.ts
@@ -1,0 +1,29 @@
+import { Type, Static } from "@sinclair/typebox";
+import { createNotFound } from "../../../utils/createNotFoundSchema.js";
+import { assetTypeSchema } from "../../../schemas/common-schemas.js";
+
+export const portfolioIdParamSchema = Type.Object({
+    portfolioId: Type.Number(),
+});
+export type PortfolioIdParam = Static<typeof portfolioIdParamSchema>;
+
+export const investmentSchema = Type.Object({
+    symbol: Type.String(),
+    assetCountryId: Type.Number(),
+    name: Type.String(),
+    type: assetTypeSchema,
+    shares: Type.Number(),
+    currentValue: Type.Number(),
+    currentAssetCurrencyValue: Type.Union([Type.Number(), Type.Null()]),
+    currentReturn: Type.Number(),
+    currentReturnPercentage: Type.Number(),
+});
+export type Investment = Static<typeof investmentSchema>;
+
+export const investmentsResponseSchema = Type.Object({
+    data: Type.Array(investmentSchema),
+});
+export type InvestmentsResponse = Static<typeof investmentsResponseSchema>;
+
+export const investmentsNotFoundSchema = createNotFound("investmentsNotFound");
+export type InvestmentsNotFound = Static<typeof investmentsNotFoundSchema>;

--- a/apps/api/stratify-api/src/utils/currency-conversion-rate-query.ts
+++ b/apps/api/stratify-api/src/utils/currency-conversion-rate-query.ts
@@ -1,0 +1,12 @@
+import db from "../database/db.js";
+
+export const currencyConversionRateQuery = (
+    fromCurrency: string,
+    toCurrency: string,
+    date: Date,
+) =>
+    db
+        .selectFrom("stratify.assetPrices as assetPrices")
+        .where("assetPrices.assetId", "=", `${fromCurrency}${toCurrency}`)
+        .where("assetPrices.priceDate", "=", date)
+        .select("assetPrices.closePrice as price");

--- a/apps/api/stratify-api/src/utils/decodeToken.ts
+++ b/apps/api/stratify-api/src/utils/decodeToken.ts
@@ -6,6 +6,7 @@ export interface UserDetails {
     userId: string;
     name: string;
     email: string;
+    defaultCurrency: string;
     username?: string;
     displayUsername?: string;
 }
@@ -32,6 +33,7 @@ export const decodeToken = async (token: string) => {
                 name: payload.name as string,
                 username: payload.username as string | undefined,
                 displayUsername: payload.displayUsername as string | undefined,
+                defaultCurrency: "GBP", // TODO: Placeholder until a currency can be set
             } satisfies UserDetails;
         }
 
@@ -46,6 +48,7 @@ export const decodeToken = async (token: string) => {
             name: payload.name as string,
             username: payload.username as string | undefined,
             displayUsername: payload.displayUsername as string | undefined,
+            defaultCurrency: "GBP", // TODO: Placeholder until a currency can be set
         } satisfies UserDetails;
     } catch (err) {
         logger.error({ err }, "Error decoding JWT");

--- a/apps/api/stratify-data-api/docs/openapi.json
+++ b/apps/api/stratify-data-api/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Stratify Data API",
     "description": "A REST API for accessing stock market data powered by Yahoo Finance and Stooq.",
-    "version": "0.3.3"
+    "version": "0.3.10"
   },
   "paths": {
     "/stocks": {

--- a/apps/ui/stratify-ui/app/(screens)/app/layout.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/layout.tsx
@@ -5,6 +5,7 @@ import { getFontClassNames } from "@/lib/fonts";
 import { Toaster } from "@/app/components/ui/sonner";
 import { SessionProvider } from "./SessionProvider";
 import AppNavbar from "@/app/components/(app)/AppNavbar";
+import { TooltipProvider } from "@/app/components/ui/tooltip";
 
 export const metadata: Metadata = {
     title: "Stratify UI",
@@ -30,7 +31,7 @@ export default function AppLayout({ children }: AuthLayoutProps) {
                 >
                     <SessionProvider>
                         <AppNavbar />
-                        {children}
+                        <TooltipProvider>{children}</TooltipProvider>
                     </SessionProvider>
                     <Toaster richColors />
                 </Providers>

--- a/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/MarketDataTable.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/MarketDataTable.tsx
@@ -98,7 +98,12 @@ const MarketDataTable = ({ selectedTab }: MarketDataTableProps) => {
 
     return (
         <div className="mt-7">
-            <DataTable columns={columns} data={assets} isLoading={isLoading} />
+            <DataTable
+                columns={columns}
+                data={assets}
+                isLoading={isLoading}
+                key={selectedTab}
+            />
         </div>
     );
 };

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.test.tsx
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import InvestmentsTable, { Investment } from "./InvestmentsTable";
+import { renderWithContext } from "@/app/tests/utils";
+import { screen } from "@testing-library/react";
+import { TooltipProvider } from "@/app/components/ui/tooltip";
+import userEvent from "@testing-library/user-event";
+
+const mockInvestmentsData = [
+    {
+        symbol: "LEON",
+        assetCountryId: 224,
+        assetCurrency: "USD",
+        name: "Leonida Inc.",
+        shares: 20,
+        type: "STOCK",
+        currentValue: 2219.2,
+        currentAssetCurrencyValue: 3040,
+        currentReturn: 1489.2,
+        currentReturnPercentage: 204,
+    },
+] satisfies Investment[];
+
+const mockUseInvestmentsList = vi.fn();
+
+vi.mock("./useInvestmentsList", () => ({
+    useInvestmentsList: () => mockUseInvestmentsList(),
+}));
+
+const user = userEvent.setup();
+
+describe("InvestmentsTable", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const renderComponent = () => {
+        renderWithContext({
+            children: (
+                <TooltipProvider>
+                    <InvestmentsTable portfolioId={1} />
+                </TooltipProvider>
+            ),
+        });
+    };
+
+    it("should render the table with data", () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: mockInvestmentsData,
+            isLoading: false,
+        });
+
+        renderComponent();
+
+        const tableHeaders = [
+            "Asset Name",
+            "Shares",
+            "Asset Type",
+            "Current Value",
+            "Return",
+        ];
+
+        tableHeaders.forEach((header) => {
+            expect(screen.getByText(header)).toBeInTheDocument();
+        });
+
+        const assetRow = [
+            "Leonida Inc. (LEON)",
+            "20",
+            "Stock",
+            "2,219.2",
+            "+ 1,489.2",
+            "+ 204%",
+        ];
+
+        assetRow.forEach((cell) => {
+            expect(screen.getByText(cell)).toBeInTheDocument();
+        });
+    });
+
+    it("should render the no results component when there are no investments", () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: [],
+            isLoading: false,
+        });
+
+        renderComponent();
+
+        expect(
+            screen.getByText("No investments found for this portfolio."),
+        ).toBeInTheDocument();
+    });
+
+    it("should render the loading state when data is loading", () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: [],
+            isLoading: true,
+        });
+
+        renderComponent();
+
+        const tableHeaders = [
+            "Asset Name",
+            "Shares",
+            "Asset Type",
+            "Current Value",
+            "Return",
+        ];
+
+        tableHeaders.forEach((header) => {
+            expect(screen.getByText(header)).toBeInTheDocument();
+        });
+
+        expect(screen.getAllByTestId("skeleton-row")).toHaveLength(5);
+    });
+
+    it("should display a tooltip if the currency of an investment is different from the user's currency", () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: mockInvestmentsData,
+            isLoading: false,
+        });
+
+        renderComponent();
+
+        const tooltipIcon = screen.getByTestId("asset-currency-info-icon");
+
+        expect(tooltipIcon).toBeInTheDocument();
+    });
+});

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
@@ -1,10 +1,9 @@
 import { paths } from "@/openapi/types/stratify-api";
-import useInvestmentsList from "./useInvestmentsList";
+import { useInvestmentsList } from "./useInvestmentsList";
 import { useAutoRefetch } from "@/app/utils/auto-refetch";
 import { DataTable } from "@/app/components/ui/data-table";
 import { columns } from "./investmentsTableColumns";
 import { AssetType } from "../../markets/MarketDataTable/MarketDataTable";
-import { Pagination } from "@/app/components/ui/pagination";
 
 export type Investment =
     paths["/portfolios/{portfolioId}/investments"]["get"]["responses"]["200"]["content"]["application/json"]["data"][number];

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
@@ -1,0 +1,58 @@
+import { paths } from "@/openapi/types/stratify-api";
+import useInvestmentsList from "./useInvestmentsList";
+import { useAutoRefetch } from "@/app/utils/auto-refetch";
+import { DataTable } from "@/app/components/ui/data-table";
+import { columns } from "./investmentsTableColumns";
+import { AssetType } from "../../markets/MarketDataTable/MarketDataTable";
+import { Pagination } from "@/app/components/ui/pagination";
+
+export type Investment =
+    paths["/portfolios/{portfolioId}/investments"]["get"]["responses"]["200"]["content"]["application/json"]["data"][number];
+
+interface InvestmentsTableProps {
+    portfolioId: number | null;
+}
+
+const noPortfolioSelectedData: Investment[] = Array.from({ length: 5 }, () => ({
+    symbol: "",
+    assetCountryId: 0,
+    assetCurrency: null,
+    name: "No portfolio selected",
+    type: "" as AssetType,
+    shares: 0,
+    currentValue: 0,
+    currentReturn: 0,
+    currentAssetCurrencyValue: null,
+    currentReturnPercentage: 0,
+}));
+
+const NoInvestmentsComponent = () => (
+    <div className="flex h-24 items-center justify-center text-sm text-primary-dark">
+        No investments found for this portfolio.
+    </div>
+);
+
+const InvestmentsTable = ({ portfolioId }: InvestmentsTableProps) => {
+    const { data, isLoading, refetch } = useInvestmentsList(portfolioId);
+
+    const intervalMs = 60 * 1000; // 1 minute
+
+    useAutoRefetch(() => refetch(), intervalMs);
+
+    const isPortfolioSelected = portfolioId !== null;
+
+    return (
+        <div className="mt-2">
+            <DataTable
+                columns={columns}
+                data={isPortfolioSelected ? data : noPortfolioSelectedData}
+                isLoading={isLoading}
+                noResultsComponent={
+                    isPortfolioSelected && <NoInvestmentsComponent />
+                }
+            />
+        </div>
+    );
+};
+
+export default InvestmentsTable;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/investmentsTableColumns.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/investmentsTableColumns.tsx
@@ -1,0 +1,155 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { Investment } from "./InvestmentsTable";
+import { Button } from "@/app/components/ui/button";
+import AssetBadge, { assetTypeMap } from "@/app/components/(app)/AssetBadge";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/app/components/ui/tooltip";
+import { InfoIcon } from "lucide-react";
+
+export const columns: ColumnDef<Investment>[] = [
+    {
+        accessorKey: "name",
+        header: "Asset Name",
+        meta: {
+            headerClassName: "w-[200px]",
+        },
+        cell: ({ row }) => {
+            const { name, symbol } = row.original;
+
+            return (
+                <Button
+                    variant="link"
+                    className="font-medium text-primary-darker hover:underline hover:text-primary-dark transition-colors"
+                >
+                    {name} {symbol.length > 0 ? `(${symbol})` : ""}
+                </Button>
+            );
+        },
+    },
+    {
+        accessorKey: "shares",
+        header: "Shares",
+        meta: {
+            align: "right",
+            headerClassName: "w-[100px]",
+        },
+        cell: ({ row }) => {
+            const shares = row.original.shares;
+
+            return <div>{shares > 0 ? shares.toLocaleString() : "---"}</div>;
+        },
+    },
+    {
+        accessorKey: "type",
+        header: "Asset Type",
+        meta: {
+            headerClassName: "w-[120px]",
+        },
+        cell: ({ row }) => {
+            const assetType = row.original.type;
+
+            return assetTypeMap[assetType] ? (
+                <AssetBadge
+                    {...assetTypeMap[assetType]}
+                    data-testid="asset-type-badge"
+                />
+            ) : (
+                "---"
+            );
+        },
+    },
+    {
+        accessorKey: "currentValue",
+        header: "Current Value",
+        meta: {
+            align: "right",
+            type: "currency",
+            headerClassName: "w-[150px]",
+        },
+        cell: ({ row }) => {
+            const { currentValue, currentAssetCurrencyValue, assetCurrency } =
+                row.original;
+
+            return (
+                <div className="flex flex-row items-center gap-x-1 justify-end">
+                    {currentValue > 0
+                        ? `${currentValue.toLocaleString()}`
+                        : "---"}
+                    {currentAssetCurrencyValue && assetCurrency && (
+                        <Tooltip>
+                            <TooltipTrigger>
+                                <InfoIcon className="w-4 h-4 text-primary-darker" />
+                            </TooltipTrigger>
+                            <TooltipContent
+                                side="right"
+                                className="font-semibold"
+                            >
+                                {currentAssetCurrencyValue.toLocaleString()}{" "}
+                                {`(${assetCurrency})`}
+                            </TooltipContent>
+                        </Tooltip>
+                    )}
+                </div>
+            );
+        },
+    },
+    {
+        accessorKey: "currentReturn",
+        header: "Return",
+        meta: {
+            align: "right",
+            headerClassName: "w-[150px]",
+        },
+        cell: ({ row }) => {
+            const { currentReturn, currentReturnPercentage } = row.original;
+
+            const isPositive = currentReturn > 0;
+            const sign = isPositive ? "+" : "";
+
+            const isPlaceholderRow = row.original.shares === 0;
+
+            return isPlaceholderRow ? (
+                "---"
+            ) : (
+                <div
+                    className={`flex flex-col justify-end text-sm leading-4 font-sans ${isPositive ? "text-positive-base" : "text-negative-base"}`}
+                >
+                    <span>
+                        {sign} {currentReturn.toLocaleString()}
+                    </span>
+                    <span>
+                        {sign} {currentReturnPercentage.toLocaleString()}%
+                    </span>
+                </div>
+            );
+        },
+    },
+    {
+        header: "",
+        id: "actions",
+        meta: {
+            type: "action",
+            headerClassName: "w-[120px]",
+        },
+        cell: ({ row }) => {
+            // TODO Implement add trade functionality to click through to a modal to add a trade for a specific investment
+            //? See AB#65
+            const { symbol, shares, assetCountryId } = row.original;
+
+            return (
+                <div className="flex flex-row gap-2">
+                    <Button
+                        disabled={shares === 0}
+                        variant="link"
+                        className="font-medium text-primary-darker hover:text-primary-dark transition-colors hover:underline hover:cursor-pointer"
+                    >
+                        Add trade
+                    </Button>
+                </div>
+            );
+        },
+    },
+];

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/investmentsTableColumns.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/investmentsTableColumns.tsx
@@ -80,7 +80,7 @@ export const columns: ColumnDef<Investment>[] = [
                         : "---"}
                     {currentAssetCurrencyValue && assetCurrency && (
                         <Tooltip>
-                            <TooltipTrigger>
+                            <TooltipTrigger data-testid="asset-currency-info-icon">
                                 <InfoIcon className="w-4 h-4 text-primary-darker" />
                             </TooltipTrigger>
                             <TooltipContent

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/useInvestmentsList.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/useInvestmentsList.ts
@@ -1,0 +1,43 @@
+import { useKyClient } from "@/lib/api/ky-client";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Investment } from "./InvestmentsTable";
+
+const useInvestmentsList = (portfolioId: number | null) => {
+    const client = useKyClient();
+    const queryClient = useQueryClient();
+
+    const cachedInvestmentsList =
+        queryClient.getQueryData<Investment[]>([
+            "investments-list",
+            portfolioId,
+        ]) || [];
+
+    const {
+        data: fetchedInvestmentsList,
+        isLoading,
+        error,
+        refetch,
+    } = useQuery({
+        queryKey: ["investments-list", portfolioId],
+        queryFn: async () =>
+            client
+                .GET("/portfolios/{portfolioId}/investments", {
+                    params: {
+                        path: {
+                            portfolioId: portfolioId ?? 0,
+                        },
+                    },
+                })
+                .then((res) => res.data?.data || []),
+        enabled: portfolioId !== null,
+    });
+
+    return {
+        data: fetchedInvestmentsList || cachedInvestmentsList,
+        isLoading,
+        error,
+        refetch,
+    };
+};
+
+export default useInvestmentsList;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/useInvestmentsList.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/useInvestmentsList.ts
@@ -2,7 +2,7 @@ import { useKyClient } from "@/lib/api/ky-client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Investment } from "./InvestmentsTable";
 
-const useInvestmentsList = (portfolioId: number | null) => {
+export const useInvestmentsList = (portfolioId: number | null) => {
     const client = useKyClient();
     const queryClient = useQueryClient();
 
@@ -39,5 +39,3 @@ const useInvestmentsList = (portfolioId: number | null) => {
         refetch,
     };
 };
-
-export default useInvestmentsList;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/SelectedPortfolio/PortfolioSelector.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/SelectedPortfolio/PortfolioSelector.test.tsx
@@ -3,12 +3,16 @@ import PortfolioSelector, { PortfolioSelectorProps } from "./PortfolioSelector";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MockPointerEvent } from "@/app/tests/_mocks/MockPointerEvent";
 
+const mockSetSelectedPortfolioId = vi.fn();
+
 const defaultPortfolioSelectorProps = {
     portfolioList: [
         { id: 1, name: "Portfolio 1" },
         { id: 2, name: "Portfolio 2" },
     ],
     isLoading: false,
+    selectedPortfolioId: null,
+    setSelectedPortfolioId: mockSetSelectedPortfolioId,
 } satisfies PortfolioSelectorProps;
 
 describe("PortfolioSelector", () => {
@@ -44,6 +48,8 @@ describe("PortfolioSelector", () => {
         renderComponent({
             portfolioList: [],
             isLoading: false,
+            selectedPortfolioId: null,
+            setSelectedPortfolioId: mockSetSelectedPortfolioId,
         });
 
         const selectButton = screen.getByText("Create a portfolio");
@@ -61,6 +67,8 @@ describe("PortfolioSelector", () => {
         renderComponent({
             portfolioList: [],
             isLoading: true,
+            selectedPortfolioId: null,
+            setSelectedPortfolioId: mockSetSelectedPortfolioId,
         });
 
         const skeleton = screen.getByTestId("loading-skeleton");

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/SelectedPortfolio/PortfolioSelector.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/SelectedPortfolio/PortfolioSelector.tsx
@@ -6,17 +6,22 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/app/components/ui/select";
-import type { PortfolioList } from "./usePortfolioList";
+import { type PortfolioList } from "./usePortfolioList";
 import { Skeleton } from "@/app/components/ui/skeleton";
+import { Dispatch, SetStateAction } from "react";
 
 export interface PortfolioSelectorProps {
     portfolioList: PortfolioList;
     isLoading: boolean;
+    selectedPortfolioId: number | null;
+    setSelectedPortfolioId: Dispatch<SetStateAction<number | null>>;
 }
 
 const PortfolioSelector = ({
     portfolioList,
     isLoading,
+    selectedPortfolioId,
+    setSelectedPortfolioId,
 }: PortfolioSelectorProps) => {
     const isSelectDisabled = portfolioList.length === 0;
 
@@ -31,7 +36,16 @@ const PortfolioSelector = ({
                     data-testid="loading-skeleton"
                 />
             ) : (
-                <Select>
+                <Select
+                    onValueChange={(value) =>
+                        setSelectedPortfolioId(parseInt(value))
+                    }
+                    value={
+                        selectedPortfolioId
+                            ? selectedPortfolioId.toString()
+                            : undefined
+                    }
+                >
                     <SelectTrigger
                         className="max-w-64"
                         disabled={isSelectDisabled}

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PortfoliosPage from "./page";
+import { renderWithContext } from "@/app/tests/utils";
+
+describe("Portfolios page", () => {
+    const renderPage = () =>
+        renderWithContext({ children: <PortfoliosPage /> });
+
+    it("should render the portfolios page", () => {
+        renderPage();
+
+        expect(screen.getByText("Portfolios")).toBeInTheDocument();
+        expect(screen.getByText("Investments")).toBeInTheDocument();
+    });
+});

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
@@ -17,6 +17,11 @@ export default function PortfoliosPage() {
                 <CreatePortfolioButton />
                 <PortfolioSelector portfolioList={data} isLoading={isLoading} />
             </div>
+            <div className="mt-8">
+                <div className="font-sans text-3xl text-primary-base font-semibold">
+                    Investments
+                </div>
+            </div>
         </div>
     );
 }

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
@@ -1,11 +1,23 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import CreatePortfolioButton from "./CreatePortfolio/CreatePortfolioButton";
 import PortfolioSelector from "./SelectedPortfolio/PortfolioSelector";
 import { usePortfolioList } from "./SelectedPortfolio/usePortfolioList";
+import InvestmentsTable from "./InvestmentsTable/InvestmentsTable";
 
 export default function PortfoliosPage() {
     const { data, isLoading } = usePortfolioList();
+
+    const [selectedPortfolioId, setSelectedPortfolioId] = useState<
+        number | null
+    >(null);
+
+    useEffect(() => {
+        if (data && data.length > 0) {
+            setSelectedPortfolioId(data[0].id);
+        }
+    }, [data]);
 
     return (
         <div className="items-center justify-items-center min-h-screen px-10">
@@ -15,12 +27,18 @@ export default function PortfoliosPage() {
 
             <div className="mt-4">
                 <CreatePortfolioButton />
-                <PortfolioSelector portfolioList={data} isLoading={isLoading} />
+                <PortfolioSelector
+                    portfolioList={data}
+                    isLoading={isLoading}
+                    selectedPortfolioId={selectedPortfolioId}
+                    setSelectedPortfolioId={setSelectedPortfolioId}
+                />
             </div>
             <div className="mt-8">
                 <div className="font-sans text-3xl text-primary-base font-semibold">
                     Investments
                 </div>
+                <InvestmentsTable portfolioId={selectedPortfolioId} />
             </div>
         </div>
     );

--- a/apps/ui/stratify-ui/app/components/Form/SubmitButton.tsx
+++ b/apps/ui/stratify-ui/app/components/Form/SubmitButton.tsx
@@ -1,13 +1,13 @@
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
-import { ButtonProps } from "../ui/button";
+import { ComponentProps } from "react";
 
 interface SubmitButtonProps {
     label: string;
     isDisabled?: boolean;
     isLoading?: boolean;
     className?: string;
-    variant?: ButtonProps["variant"];
+    variant?: ComponentProps<typeof Button>["variant"];
 }
 
 const SubmitButton = ({

--- a/apps/ui/stratify-ui/app/components/ui/button.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/button.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-sans font-medium hover:cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium font-sans transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
     {
         variants: {
             variant: {
@@ -14,18 +14,24 @@ const buttonVariants = cva(
                 destructive:
                     "bg-negative-base text-negative-lightest hover:bg-negative-dark",
                 outline:
-                    "border border-light bg-background shadow-sm hover:bg-muted-lighter hover:text-foreground-light",
+                    "border border-primary-darker text-primary-darker bg-white shadow-sm hover:text-primary-base hover:border-primary-base",
                 primaryLighter:
                     "bg-primary-lightest text-primary-dark border border-primary-base hover:bg-primary-lighter",
-                secondary: "bg-secondary-base text-secondary-lightest hover:bg-secondary-dark",
-                ghost: "hover:bg-accent-base hover:text-accent-lightest",
-                link: "text-primary-darkest underline-offset-4",
+                secondary:
+                    "bg-secondary-base text-secondary-lightest hover:bg-secondary-dark",
+                ghost: "text-primary-dark hover:text-primary-base",
+                link: "text-primary-darker hover:text-primary-base underline-offset-4",
             },
             size: {
-                default: "h-9 px-4 py-2",
-                sm: "h-8 rounded-md px-3 text-xs",
-                lg: "h-10 rounded-md px-8",
-                icon: "h-9 w-9",
+                default: "h-9 px-4 py-2 has-[>svg]:px-3",
+                xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+                sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+                lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+                icon: "size-9",
+                "icon-xs":
+                    "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+                "icon-sm": "size-8",
+                "icon-lg": "size-10",
             },
         },
         defaultVariants: {
@@ -35,25 +41,27 @@ const buttonVariants = cva(
     },
 );
 
-export interface ButtonProps
-    extends
-        React.ButtonHTMLAttributes<HTMLButtonElement>,
-        VariantProps<typeof buttonVariants> {
-    asChild?: boolean;
-}
+function Button({
+    className,
+    variant = "default",
+    size = "default",
+    asChild = false,
+    ...props
+}: React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+        asChild?: boolean;
+    }) {
+    const Comp = asChild ? Slot.Root : "button";
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-    ({ className, variant, size, asChild = false, ...props }, ref) => {
-        const Comp = asChild ? Slot : "button";
-        return (
-            <Comp
-                className={cn(buttonVariants({ variant, size, className }))}
-                ref={ref}
-                {...props}
-            />
-        );
-    },
-);
-Button.displayName = "Button";
+    return (
+        <Comp
+            data-slot="button"
+            data-variant={variant}
+            data-size={size}
+            className={cn(buttonVariants({ variant, size, className }))}
+            {...props}
+        />
+    );
+}
 
 export { Button, buttonVariants };

--- a/apps/ui/stratify-ui/app/components/ui/data-table.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/data-table.tsx
@@ -4,6 +4,8 @@ import {
     ColumnDef,
     flexRender,
     getCoreRowModel,
+    getPaginationRowModel,
+    PaginationState,
     useReactTable,
 } from "@tanstack/react-table";
 
@@ -17,158 +19,291 @@ import {
 } from "@/app/components/ui/table";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "./skeleton";
+import { ReactNode, useState } from "react";
+import {
+    Pagination,
+    PaginationContent,
+    PaginationLink,
+    PaginationNext,
+    PaginationPrevious,
+} from "./pagination";
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "./select";
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];
     data: TData[];
     isLoading?: boolean;
     isLoadingRowCount?: number;
+    noResultsComponent?: ReactNode;
+    initialPaginationState?: PaginationState;
+    isPaginationEnabled?: boolean;
 }
 
 export function DataTable<TData, TValue>({
     columns,
     data,
     isLoading,
+    noResultsComponent,
     isLoadingRowCount = 5,
+    initialPaginationState = {
+        pageIndex: 0,
+        pageSize: 5,
+    },
+    isPaginationEnabled = true,
 }: DataTableProps<TData, TValue>) {
+    const [pagination, setPagination] = useState<PaginationState>(
+        initialPaginationState,
+    );
+
     const table = useReactTable({
         data,
         columns,
         getCoreRowModel: getCoreRowModel(),
+        getPaginationRowModel: getPaginationRowModel(),
+        state: {
+            pagination: isPaginationEnabled ? pagination : undefined,
+        },
+        onPaginationChange: setPagination,
+        autoResetPageIndex: false,
     });
 
     return (
-        <div className="overflow-hidden rounded-xl border border-primary-dark">
-            <Table>
-                <TableHeader className="bg-primary-lighter">
-                    {table.getHeaderGroups().map((headerGroup) => (
-                        <TableRow key={headerGroup.id}>
-                            {headerGroup.headers.map((header) => {
-                                const align =
-                                    header.column.columnDef.meta?.align;
-                                const isCurrencyColumn =
-                                    header.column.columnDef.meta?.type ===
-                                    "currency";
-
-                                const isNumericColumn =
-                                    header.column.columnDef.meta?.type ===
-                                    "number";
-
-                                const shouldAlignRight =
-                                    align === "right" ||
-                                    isCurrencyColumn ||
-                                    isNumericColumn;
-
-                                return (
-                                    <TableHead
-                                        key={header.id}
-                                        className={cn(
-                                            "text-left", //? Default alignment
-                                            shouldAlignRight && "text-right",
-                                            align === "center" && "text-center",
-                                        )}
-                                    >
-                                        {header.isPlaceholder
-                                            ? null
-                                            : flexRender(
-                                                  header.column.columnDef
-                                                      .header,
-                                                  header.getContext(),
-                                              )}
-                                    </TableHead>
-                                );
-                            })}
-                        </TableRow>
-                    ))}
-                </TableHeader>
-                <TableBody>
-                    {isLoading ? (
-                        Array.from({ length: isLoadingRowCount }).map(
-                            (_, index) => (
-                                <TableRow
-                                    key={index}
-                                    data-testid="skeleton-row"
-                                >
-                                    {columns.map((column) => {
-                                        const key = `${column.header}-${index}`;
-                                        return (
-                                            <TableCell
-                                                key={key}
-                                                data-testid="skeleton-cell"
-                                            >
-                                                <Skeleton className="h-4 w-full" />
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            ),
-                        )
-                    ) : table.getRowModel().rows?.length ? (
-                        table.getRowModel().rows.map((row) => (
-                            <TableRow
-                                key={row.id}
-                                className="bg-muted-lightest"
-                                data-state={row.getIsSelected() && "selected"}
-                            >
-                                {row.getVisibleCells().map((cell) => {
+        <>
+            <div className="overflow-hidden rounded-xl border border-primary-dark">
+                <Table>
+                    <TableHeader className="bg-primary-lighter">
+                        {table.getHeaderGroups().map((headerGroup) => (
+                            <TableRow key={headerGroup.id}>
+                                {headerGroup.headers.map((header) => {
                                     const align =
-                                        cell.column.columnDef.meta?.align;
+                                        header.column.columnDef.meta?.align;
+                                    const isCurrencyColumn =
+                                        header.column.columnDef.meta?.type ===
+                                        "currency";
 
-                                    const isNumberColumn =
-                                        cell.column.columnDef.meta?.type ===
+                                    const isNumericColumn =
+                                        header.column.columnDef.meta?.type ===
                                         "number";
 
-                                    const cellValue = cell.getValue();
+                                    const shouldAlignRight =
+                                        align === "right" ||
+                                        isCurrencyColumn ||
+                                        isNumericColumn;
 
-                                    if (
-                                        isNumberColumn &&
-                                        typeof cellValue === "number"
-                                    ) {
-                                        const formattedValue =
-                                            cellValue.toLocaleString();
+                                    const isActionColumn =
+                                        header.column.columnDef.meta?.type ===
+                                        "action";
+
+                                    return (
+                                        <TableHead
+                                            key={header.id}
+                                            className={cn(
+                                                "text-left", //? Default alignment
+                                                shouldAlignRight &&
+                                                    "text-right",
+                                                align === "center" &&
+                                                    "text-center",
+                                                isActionColumn &&
+                                                    "text-center w-12",
+                                                header.column.columnDef.meta
+                                                    ?.headerClassName,
+                                            )}
+                                        >
+                                            {header.isPlaceholder
+                                                ? null
+                                                : flexRender(
+                                                      header.column.columnDef
+                                                          .header,
+                                                      header.getContext(),
+                                                  )}
+                                        </TableHead>
+                                    );
+                                })}
+                            </TableRow>
+                        ))}
+                    </TableHeader>
+                    <TableBody>
+                        {isLoading ? (
+                            Array.from({ length: isLoadingRowCount }).map(
+                                (_, index) => (
+                                    <TableRow
+                                        key={index}
+                                        data-testid="skeleton-row"
+                                    >
+                                        {columns.map((column) => {
+                                            const key = `${column.header}-${index}`;
+                                            return (
+                                                <TableCell
+                                                    key={key}
+                                                    data-testid="skeleton-cell"
+                                                >
+                                                    <Skeleton className="h-4 w-full" />
+                                                </TableCell>
+                                            );
+                                        })}
+                                    </TableRow>
+                                ),
+                            )
+                        ) : table.getRowModel().rows?.length ? (
+                            table.getRowModel().rows.map((row) => (
+                                <TableRow
+                                    key={row.id}
+                                    className="bg-muted-lightest"
+                                    data-state={
+                                        row.getIsSelected() && "selected"
+                                    }
+                                >
+                                    {row.getVisibleCells().map((cell) => {
+                                        const align =
+                                            cell.column.columnDef.meta?.align;
+
+                                        const isNumberColumn =
+                                            cell.column.columnDef.meta?.type ===
+                                            "number";
+
+                                        const cellValue = cell.getValue();
+
+                                        if (
+                                            isNumberColumn &&
+                                            typeof cellValue === "number"
+                                        ) {
+                                            const formattedValue =
+                                                cellValue.toLocaleString();
+
+                                            return (
+                                                <TableCell
+                                                    key={cell.id}
+                                                    className="text-right"
+                                                >
+                                                    {formattedValue}
+                                                </TableCell>
+                                            );
+                                        }
 
                                         return (
                                             <TableCell
                                                 key={cell.id}
-                                                className="text-right"
+                                                className={cn(
+                                                    "text-left",
+                                                    align === "right" &&
+                                                        "text-right",
+                                                    align === "center" &&
+                                                        "text-center",
+                                                )}
                                             >
-                                                {formattedValue}
+                                                {flexRender(
+                                                    cell.column.columnDef.cell,
+                                                    cell.getContext(),
+                                                )}
                                             </TableCell>
                                         );
-                                    }
-
-                                    return (
-                                        <TableCell
-                                            key={cell.id}
-                                            className={cn(
-                                                "text-left",
-                                                align === "right" &&
-                                                    "text-right",
-                                                align === "center" &&
-                                                    "text-center",
-                                            )}
-                                        >
-                                            {flexRender(
-                                                cell.column.columnDef.cell,
-                                                cell.getContext(),
-                                            )}
-                                        </TableCell>
-                                    );
-                                })}
+                                    })}
+                                </TableRow>
+                            ))
+                        ) : (
+                            <TableRow>
+                                <TableCell colSpan={columns.length}>
+                                    {noResultsComponent || (
+                                        <div className="text-center">
+                                            No results found
+                                        </div>
+                                    )}
+                                </TableCell>
                             </TableRow>
-                        ))
-                    ) : (
-                        <TableRow>
-                            <TableCell
-                                colSpan={columns.length}
-                                className="h-24 text-center"
+                        )}
+                    </TableBody>
+                </Table>
+            </div>
+            {isPaginationEnabled && (
+                <Pagination className="flex flex-row mt-2.5 px-2.5 justify-between">
+                    <div className="flex flex-row items-center gap-x-2">
+                        <div
+                            className={cn(
+                                "text-sm font-sans font-medium text-center text-primary-darker text-nowrap",
+                                table.getPageCount() === 0 && "opacity-50",
+                            )}
+                        >
+                            Rows per page
+                        </div>
+                        <Select
+                            value={pagination.pageSize.toString()}
+                            onValueChange={(value) => {
+                                setPagination({
+                                    ...pagination,
+                                    pageSize: parseInt(value),
+                                });
+                            }}
+                        >
+                            <SelectTrigger
+                                className="max-w-20 items-center border-primary-dark bg-white"
+                                disabled={table.getPageCount() === 0}
                             >
-                                No results.
-                            </TableCell>
-                        </TableRow>
-                    )}
-                </TableBody>
-            </Table>
-        </div>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent
+                                side="bottom"
+                                align="start"
+                                className="border-primary-dark bg-white"
+                            >
+                                <SelectGroup className="flex flex-col gap-y-1">
+                                    {[5, 10, 20].map((rowCount) => (
+                                        <SelectItem
+                                            key={rowCount}
+                                            value={rowCount.toString()}
+                                            className="data-highlighted:bg-primary-lightest"
+                                        >
+                                            {rowCount}
+                                        </SelectItem>
+                                    ))}
+                                </SelectGroup>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="flex flex-row items-center">
+                        <PaginationPrevious
+                            onClick={() => table.previousPage()}
+                            className={cn(
+                                !table.getCanPreviousPage() &&
+                                    "opacity-50 cursor-default",
+                            )}
+                            href="#"
+                        />
+                        <PaginationContent>
+                            {Array.from({ length: table.getPageCount() }).map(
+                                (_, index) => (
+                                    <PaginationLink
+                                        key={index}
+                                        onClick={() =>
+                                            table.setPageIndex(index)
+                                        }
+                                        isActive={
+                                            index === pagination.pageIndex
+                                        }
+                                        href="#"
+                                    >
+                                        {index + 1}
+                                    </PaginationLink>
+                                ),
+                            )}
+                        </PaginationContent>
+                        <PaginationNext
+                            onClick={() => table.nextPage()}
+                            className={cn(
+                                !table.getCanNextPage() &&
+                                    "opacity-50 cursor-default",
+                            )}
+                            href="#"
+                        />
+                    </div>
+                </Pagination>
+            )}
+        </>
     );
 }

--- a/apps/ui/stratify-ui/app/components/ui/data-table.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/data-table.tsx
@@ -212,7 +212,7 @@ export function DataTable<TData, TValue>({
                                 <TableCell colSpan={columns.length}>
                                     {noResultsComponent || (
                                         <div className="text-center">
-                                            No results found
+                                            No results.
                                         </div>
                                     )}
                                 </TableCell>

--- a/apps/ui/stratify-ui/app/components/ui/pagination.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/pagination.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+import Link from "next/link";
+import {
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    MoreHorizontalIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants, type Button } from "@/app/components/ui/button";
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+    return (
+        <nav
+            role="navigation"
+            aria-label="pagination"
+            data-slot="pagination"
+            className={cn("mx-auto flex w-full justify-center", className)}
+            {...props}
+        />
+    );
+}
+
+function PaginationContent({
+    className,
+    ...props
+}: React.ComponentProps<"ul">) {
+    return (
+        <ul
+            data-slot="pagination-content"
+            className={cn("flex flex-row items-center gap-1", className)}
+            {...props}
+        />
+    );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+    return <li data-slot="pagination-item" {...props} />;
+}
+
+type PaginationLinkProps = {
+    isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+    React.ComponentProps<typeof Link>;
+
+function PaginationLink({
+    className,
+    isActive,
+    size = "icon",
+    ...props
+}: PaginationLinkProps) {
+    return (
+        <Link
+            aria-current={isActive ? "page" : undefined}
+            data-slot="pagination-link"
+            data-active={isActive}
+            className={cn(
+                buttonVariants({
+                    variant: isActive ? "outline" : "ghost",
+                    size,
+                }),
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function PaginationPrevious({
+    className,
+    ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+    return (
+        <PaginationLink
+            aria-label="Go to previous page"
+            size="default"
+            className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+            {...props}
+        >
+            <ChevronLeftIcon />
+            <span className="hidden sm:block">Previous</span>
+        </PaginationLink>
+    );
+}
+
+function PaginationNext({
+    className,
+    ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+    return (
+        <PaginationLink
+            aria-label="Go to next page"
+            size="default"
+            className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+            {...props}
+        >
+            <span className="hidden sm:block">Next</span>
+            <ChevronRightIcon />
+        </PaginationLink>
+    );
+}
+
+function PaginationEllipsis({
+    className,
+    ...props
+}: React.ComponentProps<"span">) {
+    return (
+        <span
+            aria-hidden
+            data-slot="pagination-ellipsis"
+            className={cn("flex size-9 items-center justify-center", className)}
+            {...props}
+        >
+            <MoreHorizontalIcon className="size-4" />
+            <span className="sr-only">More pages</span>
+        </span>
+    );
+}
+
+export {
+    Pagination,
+    PaginationContent,
+    PaginationLink,
+    PaginationItem,
+    PaginationPrevious,
+    PaginationNext,
+    PaginationEllipsis,
+};

--- a/apps/ui/stratify-ui/app/components/ui/select.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
     <SelectPrimitive.Trigger
         ref={ref}
         className={cn(
-            "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-primary-base bg-primary-lightest px-3 py-2 text-sm text-primary-dark shadow-sm ring-primary-base data-placeholder:text-muted-dark focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 cursor-pointer font-sans font-medium",
+            "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-primary-base bg-primary-lightest px-3 py-2 text-sm text-primary-dark shadow-sm ring-primary-base data-placeholder:text-muted-dark focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 cursor-pointer font-sans font-medium gap-x-1",
             className,
         )}
         {...props}

--- a/apps/ui/stratify-ui/app/components/ui/tooltip.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+    delayDuration = 0,
+    ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+    return (
+        <TooltipPrimitive.Provider
+            data-slot="tooltip-provider"
+            delayDuration={delayDuration}
+            {...props}
+        />
+    );
+}
+
+function Tooltip({
+    ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+    return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+    ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+    return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+    className,
+    sideOffset = 0,
+    children,
+    ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+    return (
+        <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+                data-slot="tooltip-content"
+                sideOffset={sideOffset}
+                className={cn(
+                    "bg-primary-base font-sans text-primary-lightest animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+                    className,
+                )}
+                {...props}
+            >
+                {children}
+                <TooltipPrimitive.Arrow className="bg-primary-base fill-primary-base z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+            </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+    );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/ui/stratify-ui/app/components/ui/types/tanstack-table.d.ts
+++ b/apps/ui/stratify-ui/app/components/ui/types/tanstack-table.d.ts
@@ -3,7 +3,7 @@ import "@tanstack/react-table";
 declare module "@tanstack/react-table" {
     interface ColumnMeta<TData extends RowData, TValue> {
         align?: "left" | "center" | "right"; //? Alignment for headers and cells in a specific column
-        type?: "text" | "number" | "currency" | "badge"; //? Type for formatting headers and cells properly
-        currency?: string; //? Currency code for currency columns
+        type?: "text" | "number" | "currency" | "badge" | "action"; //? Type for formatting headers and cells properly
+        headerClassName?: string; //? Additional className for header cells
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4019,7 +4019,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9038,7 +9038,7 @@ snapshots:
       magicast: 0.5.1
       obug: 2.1.1
       tinyrainbow: 3.0.3
-      vitest: 4.0.17(@types/node@20.19.27)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.17(@types/node@25.0.3)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9093,7 +9093,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.17(@types/node@20.19.27)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.17(@types/node@25.0.3)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@4.0.17':
     dependencies:
@@ -9880,7 +9880,7 @@ snapshots:
       '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -9904,7 +9904,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
@@ -9919,14 +9919,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9948,7 +9948,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## stratify-ui
- Build data table to display the investments in a portfolio
- Add unit tests for the investments table
- Improve data table with pagination
- Set selected portfolio to the first portfolio in the list when the user navigates to the portfolios page
## stratify-api
- Build endpoint to retrieve the investments in a portfolio
- Add unit tests for the endpoint
- Add migration to change the primary key for the trades table to an auto-incrementing number instead of a composite key made up of the asset symbol, trade date and portfolio id
- Add column to store the total amount of a trade in the currency of the asset in the trades table