### PR TITLE
Ab#78 -Asset allocation chart

### DIFF
--- a/.changeset/fluffy-taxis-teach.md
+++ b/.changeset/fluffy-taxis-teach.md
@@ -1,0 +1,6 @@
+---
+"@stratify/stratify-api": patch
+---
+
+- Change function for retrieving investments to retrieve the sector for each asset (or sectors and the weights for those sectors if it is a fund)
+- Organise functions and endpoint files related to individual portfolios into separate folders

--- a/.changeset/tender-regions-hunt.md
+++ b/.changeset/tender-regions-hunt.md
@@ -1,0 +1,10 @@
+---
+"@stratify/stratify-ui": minor
+---
+
+- Build component for displaying the asset allocation for a portfolio within a pie chart
+- Allow for grouping assets by asset class, sector or country in the pie chart
+- Display a tooltip when hovering over a sector in the pie chart to display information relevant to that sector based on the grouping
+- Display a legend in place of the pie chart through a toggle to show which colours correspond to which sectors in the pie chart
+- Add unit tests for the asset allocation component
+- Change the layout of the portfolio page to display the asset allocation component in line with the overall return and overall risk cards

--- a/.changeset/thin-states-change.md
+++ b/.changeset/thin-states-change.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-data-api": minor
+---
+
+Change fund endpoints to retrieve the sector weights for the assets held in each fund and add mappings to ensure that the sector names are consistent between funds and stocks

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/add-trade/[portfolioId].add-trade.post.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/add-trade/[portfolioId].add-trade.post.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import loadMockApp from "../../../__mocks__/mockApp.js";
-import db from "../../../database/db.js";
-import { createUser } from "../../../tests/create-user.js";
-import { generateDevToken } from "../../../utils/generateDevToken.js";
+import loadMockApp from "../../../../__mocks__/mockApp.js";
+import db from "../../../../database/db.js";
+import { createUser } from "../../../../tests/create-user.js";
+import { generateDevToken } from "../../../../utils/generateDevToken.js";
 
 describe("POST /portfolios/:portfolioId/add-trade", () => {
     let devToken = "";

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/add-trade/[portfolioId].add-trade.post.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/add-trade/[portfolioId].add-trade.post.ts
@@ -3,13 +3,13 @@ import { FastifyInstance } from "fastify";
 import {
     PortfolioIdParam,
     portfolioIdParamSchema,
-} from "./investments.schema.js";
-import { getFromStore } from "../../../plugins/localStorage.js";
-import { UserDetails } from "../../../utils/decodeToken.js";
-import logger from "../../../logger.js";
-import db from "../../../database/db.js";
-import { createNotFound } from "../../../utils/createNotFoundSchema.js";
-import { portfolioExistsForUserCheck } from "./portfolioExistsQuery.js";
+} from "../investments/investments.schema.js";
+import { getFromStore } from "../../../../plugins/localStorage.js";
+import { UserDetails } from "../../../../utils/decodeToken.js";
+import logger from "../../../../logger.js";
+import db from "../../../../database/db.js";
+import { createNotFound } from "../../../../utils/createNotFoundSchema.js";
+import { portfolioExistsForUserCheck } from "../portfolioExistsQuery.js";
 
 const requestBodySchema = Type.Object({
     assetId: Type.Number(),

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.test.ts
@@ -20,7 +20,7 @@ const mockDataApiClient = {
     GET: mockGetCurrentPrice,
 };
 
-vi.mock("../../../lib/api/data-api-client", () => ({
+vi.mock("../../../../lib/api/data-api-client", () => ({
     dataApiClient: () => mockDataApiClient,
 }));
 

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import loadMockApp from "../../../__mocks__/mockApp.js";
-import db from "../../../database/db.js";
-import { createUser } from "../../../tests/create-user.js";
-import { generateDevToken } from "../../../utils/generateDevToken.js";
+import loadMockApp from "../../../../__mocks__/mockApp.js";
+import db from "../../../../database/db.js";
+import { createUser } from "../../../../tests/create-user.js";
+import { generateDevToken } from "../../../../utils/generateDevToken.js";
 
 const mockAssetPriceResponse = {
     data: {

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.test.ts
@@ -3,6 +3,7 @@ import loadMockApp from "../../../../__mocks__/mockApp.js";
 import db from "../../../../database/db.js";
 import { createUser } from "../../../../tests/create-user.js";
 import { generateDevToken } from "../../../../utils/generateDevToken.js";
+import { _null } from "better-auth";
 
 const mockAssetPriceResponse = {
     data: {
@@ -16,8 +17,55 @@ const mockAssetPriceResponse = {
 
 const mockGetCurrentPrice = vi.fn().mockResolvedValue(mockAssetPriceResponse);
 
+const mockStockSectorDetailsResponse = {
+    data: {
+        data: {
+            industryDetails: {
+                sector: "technology",
+            },
+        },
+    },
+};
+
+const mockFetchStockDetails = vi
+    .fn()
+    .mockResolvedValue(mockStockSectorDetailsResponse);
+
+const mockFundSectorDetailsResponse = {
+    data: {
+        data: {
+            sectorWeights: [
+                {
+                    sector: "technology",
+                    weight: 0.6,
+                },
+                {
+                    sector: "financials",
+                    weight: 0.4,
+                },
+            ],
+        },
+    },
+};
+
+const mockFetchFundDetails = vi
+    .fn()
+    .mockResolvedValue(mockFundSectorDetailsResponse);
+
 const mockDataApiClient = {
-    GET: mockGetCurrentPrice,
+    GET: (url: string) => {
+        if (url.includes("/current-price")) {
+            return mockGetCurrentPrice();
+        }
+
+        if (url.includes("/stocks")) {
+            return mockFetchStockDetails();
+        }
+
+        if (url.includes("/funds")) {
+            return mockFetchFundDetails();
+        }
+    },
 };
 
 vi.mock("../../../../lib/api/data-api-client", () => ({
@@ -73,6 +121,14 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                     currency: "USD",
                     type: "CURRENCY",
                     countryId: 224, // Country ID for united states
+                },
+                {
+                    id: 4,
+                    name: "A fund",
+                    symbol: "FUND",
+                    currency: "GBP",
+                    type: "ETF",
+                    countryId: 223, // Country ID for united kingdom
                 },
             ])
             .execute();
@@ -134,6 +190,16 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                     tradeAction: "BUY",
                     tradeDate: new Date("2026-02-04"),
                 },
+                {
+                    portfolioId: portfolio.id,
+                    assetId: 4,
+                    quantity: 10,
+                    pricePerShare: 50,
+                    totalAmount: 500,
+                    assetCurrencyTotalAmount: 500,
+                    tradeAction: "BUY",
+                    tradeDate: new Date("2026-02-05"),
+                },
             ])
             .execute();
 
@@ -165,6 +231,36 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                     currentReturn: 164.4,
                     currentReturnPercentage: 10.96,
                     totalBuyAmount: 1500,
+                    sectorDetails: [
+                        {
+                            sector: "technology",
+                            weight: 1,
+                        },
+                    ],
+                },
+                {
+                    assetId: 4,
+                    symbol: "FUND",
+                    assetCountryId: 223,
+                    assetCurrency: "GBP",
+                    name: "A fund",
+                    shares: 10,
+                    type: "ETF",
+                    currentValue: 1520,
+                    currentAssetCurrencyValue: null,
+                    currentReturn: 1020,
+                    currentReturnPercentage: 204,
+                    totalBuyAmount: 500,
+                    sectorDetails: [
+                        {
+                            sector: "technology",
+                            weight: 0.6,
+                        },
+                        {
+                            sector: "financials",
+                            weight: 0.4,
+                        },
+                    ],
                 },
                 {
                     assetId: 2,
@@ -179,6 +275,12 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                     currentReturn: 359.6,
                     currentReturnPercentage: 47.95,
                     totalBuyAmount: 750,
+                    sectorDetails: [
+                        {
+                            sector: "technology",
+                            weight: 1,
+                        },
+                    ],
                 },
             ],
         });
@@ -279,6 +381,12 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                     currentReturn: 30,
                     currentReturnPercentage: 1.33,
                     totalBuyAmount: 2250,
+                    sectorDetails: [
+                        {
+                            sector: "technology",
+                            weight: 1,
+                        },
+                    ],
                 },
                 {
                     assetId: 2,
@@ -293,6 +401,12 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                     currentReturn: 260,
                     currentReturnPercentage: 52,
                     totalBuyAmount: 500,
+                    sectorDetails: [
+                        {
+                            sector: "technology",
+                            weight: 1,
+                        },
+                    ],
                 },
             ],
         });
@@ -384,6 +498,12 @@ describe("GET /portfolios/:portfolioId/investments", () => {
                     currentReturn: 120,
                     currentReturnPercentage: 5.33,
                     totalBuyAmount: 2250,
+                    sectorDetails: [
+                        {
+                            sector: "technology",
+                            weight: 1,
+                        },
+                    ],
                 },
             ],
         });

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/[portfolioId].investments.get.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from "fastify";
-import logger from "../../../logger.js";
+import logger from "../../../../logger.js";
 import {
     InvestmentsNotFound,
     investmentsNotFoundSchema,

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/fetchFundDetails.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/fetchFundDetails.ts
@@ -1,0 +1,32 @@
+import { dataApiClient } from "../../../../lib/api/data-api-client.js";
+import logger from "../../../../logger.js";
+
+export const fetchFundDetails = async (
+    assetSymbol: string,
+    assetCountryId: number,
+) => {
+    // Append .L for London Stock Exchange assets (UK assets)
+    const symbol = assetCountryId === 223 ? `${assetSymbol}.L` : assetSymbol;
+
+    try {
+        const response = await dataApiClient()
+            .GET("/funds/{symbol}", {
+                params: {
+                    path: {
+                        symbol,
+                    },
+                },
+            })
+            .then((res) => res.data?.data);
+
+        return response;
+    } catch (error) {
+        logger.error(
+            {
+                error,
+                symbol,
+            },
+            "Error fetching details for fund",
+        );
+    }
+};

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/fetchStockDetails.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/fetchStockDetails.ts
@@ -1,0 +1,32 @@
+import { dataApiClient } from "../../../../lib/api/data-api-client.js";
+import logger from "../../../../logger.js";
+
+export const fetchStockDetails = async (
+    assetSymbol: string,
+    assetCountryId: number,
+) => {
+    // Append .L for London Stock Exchange assets (UK assets)
+    const symbol = assetCountryId === 223 ? `${assetSymbol}.L` : assetSymbol;
+
+    try {
+        const response = await dataApiClient()
+            .GET("/stocks/{symbol}", {
+                params: {
+                    path: {
+                        symbol,
+                    },
+                },
+            })
+            .then((res) => res.data?.data);
+
+        return response;
+    } catch (error) {
+        logger.error(
+            {
+                error,
+                symbol,
+            },
+            "Error fetching details for stock",
+        );
+    }
+};

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/formatInvestmentDetails.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/formatInvestmentDetails.ts
@@ -1,5 +1,5 @@
-import { AssetType } from "../../../schemas/common-schemas.js";
-import { latestCurrencyConversionRateQuery } from "../../../utils/latestCurrencyRateQuery.js";
+import { AssetType } from "../../../../schemas/common-schemas.js";
+import { latestCurrencyConversionRateQuery } from "../../../../utils/latestCurrencyRateQuery.js";
 import type { Investment } from "./investments.schema.js";
 import { GroupedInvestment } from "./retrievePortfolioInvestments.js";
 

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/formatInvestmentDetails.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/formatInvestmentDetails.ts
@@ -1,12 +1,13 @@
 import { AssetType } from "../../../../schemas/common-schemas.js";
 import { latestCurrencyConversionRateQuery } from "../../../../utils/latestCurrencyRateQuery.js";
-import type { Investment } from "./investments.schema.js";
-import { GroupedInvestment } from "./retrievePortfolioInvestments.js";
+import type { Investment, SectorDetails } from "./investments.schema.js";
+import type { GroupedInvestment } from "./retrievePortfolioInvestments.js";
 
 export const formatInvestmentDetails = async (
     investment: GroupedInvestment,
     currentInvestmentValue: number,
     userCurrency: string | null,
+    sectorDetails: SectorDetails[],
 ) => {
     const {
         symbol,
@@ -70,5 +71,6 @@ export const formatInvestmentDetails = async (
             : null,
         currentReturn: parseFloat(currentReturn.toFixed(2)),
         currentReturnPercentage: parseFloat(currentReturnPercentage.toFixed(2)),
+        sectorDetails,
     } satisfies Investment;
 };

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/investments.schema.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/investments.schema.ts
@@ -7,6 +7,13 @@ export const portfolioIdParamSchema = Type.Object({
 });
 export type PortfolioIdParam = Static<typeof portfolioIdParamSchema>;
 
+const sectorDetails = Type.Object({
+    sector: Type.String(),
+    weight: Type.Number(),
+});
+
+export type SectorDetails = Static<typeof sectorDetails>;
+
 export const investmentSchema = Type.Object({
     assetId: Type.Number(),
     symbol: Type.String(),
@@ -20,6 +27,7 @@ export const investmentSchema = Type.Object({
     currentAssetCurrencyValue: Type.Union([Type.Number(), Type.Null()]),
     currentReturn: Type.Number(),
     currentReturnPercentage: Type.Number(),
+    sectorDetails: Type.Array(sectorDetails),
 });
 export type Investment = Static<typeof investmentSchema>;
 

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/investments.schema.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/investments.schema.ts
@@ -1,6 +1,6 @@
 import { Type, Static } from "@sinclair/typebox";
-import { createNotFound } from "../../../utils/createNotFoundSchema.js";
-import { assetTypeSchema } from "../../../schemas/common-schemas.js";
+import { createNotFound } from "../../../../utils/createNotFoundSchema.js";
+import { assetTypeSchema } from "../../../../schemas/common-schemas.js";
 
 export const portfolioIdParamSchema = Type.Object({
     portfolioId: Type.Number(),

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/retrievePortfolioInvestments.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/retrievePortfolioInvestments.ts
@@ -4,6 +4,9 @@ import { UserDetails } from "../../../../utils/decodeToken.js";
 import { fetchCurrentPrice } from "../../../assets/fetch-current-price.js";
 import { formatInvestmentDetails } from "./formatInvestmentDetails.js";
 import { portfolioInvestmentsQuery } from "../portfolioInvestmentsQuery.js";
+import { fetchStockDetails } from "./fetchStockDetails.js";
+import { fetchFundDetails } from "./fetchFundDetails.js";
+import { SectorDetails } from "./investments.schema.js";
 
 export interface GroupedInvestment {
     id: number;
@@ -17,6 +20,40 @@ export interface GroupedInvestment {
     totalBuyAmount: number;
     realisedReturn: number;
 }
+
+const retrieveSectorDetails = async (
+    symbol: string,
+    countryId: number,
+    type: AssetType,
+): Promise<SectorDetails[]> => {
+    if (type === "CRYPTOCURRENCY") {
+        return [
+            {
+                sector: "cryptocurrency",
+                weight: 1,
+            },
+        ];
+    } else if (type === "STOCK") {
+        const stockDetails = await fetchStockDetails(symbol, countryId);
+
+        if (stockDetails?.industryDetails.sector) {
+            return [
+                {
+                    sector: stockDetails.industryDetails.sector,
+                    weight: 1,
+                },
+            ];
+        }
+    } else {
+        const fundDetails = await fetchFundDetails(symbol, countryId);
+
+        if (fundDetails?.sectorWeights) {
+            return fundDetails.sectorWeights;
+        }
+    }
+
+    return [];
+};
 
 export const retrieveInvestments = async (portfolioId: number) => {
     const { userId, userCurrency } = getFromStore("user") as UserDetails;
@@ -122,11 +159,18 @@ export const retrieveInvestments = async (portfolioId: number) => {
                 return price * investment.shares;
             });
 
+            const sectorDetails = await retrieveSectorDetails(
+                symbol,
+                countryId,
+                type,
+            );
+
             //? Format the details of the investment, convert the monetary amounts by currency if needed and return it
             return await formatInvestmentDetails(
                 investment,
                 currentInvestmentValue,
                 userCurrency,
+                sectorDetails,
             );
         }),
     );

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/retrievePortfolioInvestments.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/investments/retrievePortfolioInvestments.ts
@@ -1,9 +1,9 @@
-import { getFromStore } from "../../../plugins/localStorage.js";
-import { AssetType } from "../../../schemas/common-schemas.js";
-import { UserDetails } from "../../../utils/decodeToken.js";
-import { fetchCurrentPrice } from "../../assets/fetch-current-price.js";
+import { getFromStore } from "../../../../plugins/localStorage.js";
+import { AssetType } from "../../../../schemas/common-schemas.js";
+import { UserDetails } from "../../../../utils/decodeToken.js";
+import { fetchCurrentPrice } from "../../../assets/fetch-current-price.js";
 import { formatInvestmentDetails } from "./formatInvestmentDetails.js";
-import { portfolioInvestmentsQuery } from "./portfolioInvestmentsQuery.js";
+import { portfolioInvestmentsQuery } from "../portfolioInvestmentsQuery.js";
 
 export interface GroupedInvestment {
     id: number;

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.test.ts
@@ -21,7 +21,7 @@ const mockDataApiClient = {
     GET: mockGetCurrentPrice,
 };
 
-vi.mock("../../../lib/api/data-api-client", () => ({
+vi.mock("../../../../lib/api/data-api-client", () => ({
     dataApiClient: () => mockDataApiClient,
 }));
 

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import loadMockApp from "../../../__mocks__/mockApp.js";
-import db from "../../../database/db.js";
-import { createUser } from "../../../tests/create-user.js";
-import { generateDevToken } from "../../../utils/generateDevToken.js";
-import { mockHistoricAssetPrices } from "./_mocks/mockHistoricAssetPrices.js";
+import loadMockApp from "../../../../__mocks__/mockApp.js";
+import db from "../../../../database/db.js";
+import { createUser } from "../../../../tests/create-user.js";
+import { generateDevToken } from "../../../../utils/generateDevToken.js";
+import { mockHistoricAssetPrices } from "../_mocks/mockHistoricAssetPrices.js";
 
 const mockAssetPriceResponse = {
     data: {

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.test.ts
@@ -17,8 +17,30 @@ const mockAssetPriceResponse = {
 
 const mockGetCurrentPrice = vi.fn().mockResolvedValue(mockAssetPriceResponse);
 
+const mockSectorDetailsResponse = {
+    data: {
+        data: {
+            industryDetails: {
+                sector: "technology",
+            },
+        },
+    },
+};
+
+const mockFetchStockDetails = vi
+    .fn()
+    .mockResolvedValue(mockSectorDetailsResponse);
+
 const mockDataApiClient = {
-    GET: mockGetCurrentPrice,
+    GET: (url: string) => {
+        if (url.includes("/current-price")) {
+            return mockGetCurrentPrice();
+        }
+
+        if (url.includes("/stocks")) {
+            return mockFetchStockDetails();
+        }
+    },
 };
 
 vi.mock("../../../../lib/api/data-api-client", () => ({

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/[portfolioId].metrics.get.ts
@@ -1,16 +1,16 @@
 import { Static, Type } from "@sinclair/typebox";
-import { createNotFound } from "../../../utils/createNotFoundSchema.js";
+import { createNotFound } from "../../../../utils/createNotFoundSchema.js";
 import { FastifyInstance } from "fastify";
 import {
     PortfolioIdParam,
     portfolioIdParamSchema,
-} from "./investments.schema.js";
-import { getFromStore } from "../../../plugins/localStorage.js";
-import { UserDetails } from "../../../utils/decodeToken.js";
-import { portfolioExistsForUserCheck } from "./portfolioExistsQuery.js";
-import { retrieveInvestments } from "./retrievePortfolioInvestments.js";
+} from "../investments/investments.schema.js";
+import { getFromStore } from "../../../../plugins/localStorage.js";
+import { UserDetails } from "../../../../utils/decodeToken.js";
+import { portfolioExistsForUserCheck } from "../portfolioExistsQuery.js";
+import { retrieveInvestments } from "../investments/retrievePortfolioInvestments.js";
 import { calculateAssetVariance } from "./calculateAssetVariance.js";
-import logger from "../../../logger.js";
+import logger from "../../../../logger.js";
 
 const riskLevelValues = [
     "low",

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/calculateAssetVariance.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/metrics/calculateAssetVariance.ts
@@ -1,4 +1,4 @@
-import db from "../../../database/db.js";
+import db from "../../../../database/db.js";
 
 export const calculateAssetVariance = async (assetId: number) => {
     //? Calculate the variance and downside variance based on monthly returns over the last 5 years

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/value-history/[portfolioId].value-history.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/value-history/[portfolioId].value-history.get.ts
@@ -2,17 +2,17 @@ import { FastifyInstance } from "fastify";
 import {
     PortfolioIdParam,
     portfolioIdParamSchema,
-} from "./investments.schema.js";
-import logger from "../../../logger.js";
-import { getFromStore } from "../../../plugins/localStorage.js";
-import { UserDetails } from "../../../utils/decodeToken.js";
+} from "../investments/investments.schema.js";
+import logger from "../../../../logger.js";
+import { getFromStore } from "../../../../plugins/localStorage.js";
+import { UserDetails } from "../../../../utils/decodeToken.js";
 import { Static, Type } from "@sinclair/typebox";
-import { createNotFound } from "../../../utils/createNotFoundSchema.js";
-import { fetchCurrentPrice } from "../../assets/fetch-current-price.js";
-import db from "../../../database/db.js";
-import { AssetType } from "../../../schemas/common-schemas.js";
-import { latestCurrencyConversionRateQuery } from "../../../utils/latestCurrencyRateQuery.js";
-import { portfolioInvestmentsQuery } from "./portfolioInvestmentsQuery.js";
+import { createNotFound } from "../../../../utils/createNotFoundSchema.js";
+import { fetchCurrentPrice } from "../../../assets/fetch-current-price.js";
+import db from "../../../../database/db.js";
+import { AssetType } from "../../../../schemas/common-schemas.js";
+import { latestCurrencyConversionRateQuery } from "../../../../utils/latestCurrencyRateQuery.js";
+import { portfolioInvestmentsQuery } from "../portfolioInvestmentsQuery.js";
 
 const valueHistorySchema = Type.Object({
     portfolioValue: Type.Number(),

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/value-history/[portfolioId].value-history.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/value-history/[portfolioId].value-history.test.ts
@@ -20,7 +20,7 @@ const mockDataApiClient = {
     GET: mockGetCurrentPrice,
 };
 
-vi.mock("../../../lib/api/data-api-client", () => ({
+vi.mock("../../../../lib/api/data-api-client", () => ({
     dataApiClient: () => mockDataApiClient,
 }));
 

--- a/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/value-history/[portfolioId].value-history.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/[portfolioId]/value-history/[portfolioId].value-history.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import loadMockApp from "../../../__mocks__/mockApp.js";
-import db from "../../../database/db.js";
-import { createUser } from "../../../tests/create-user.js";
-import { generateDevToken } from "../../../utils/generateDevToken.js";
+import loadMockApp from "../../../../__mocks__/mockApp.js";
+import db from "../../../../database/db.js";
+import { createUser } from "../../../../tests/create-user.js";
+import { generateDevToken } from "../../../../utils/generateDevToken.js";
 
 const mockAssetPriceResponse = {
     data: {

--- a/apps/api/stratify-data-api/docs/openapi.json
+++ b/apps/api/stratify-data-api/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Stratify Data API",
     "description": "A REST API for accessing stock market data powered by Yahoo Finance and Stooq.",
-    "version": "0.3.10"
+    "version": "0.3.12"
   },
   "paths": {
     "/stocks": {
@@ -739,6 +739,13 @@
           },
           "priceDetails": {
             "$ref": "#/components/schemas/PriceDetails"
+          },
+          "sectorWeights": {
+            "items": {
+              "$ref": "#/components/schemas/SectorWeight"
+            },
+            "type": "array",
+            "title": "Sectorweights"
           }
         },
         "type": "object",
@@ -751,7 +758,8 @@
           "marketState",
           "currency",
           "exchange",
-          "priceDetails"
+          "priceDetails",
+          "sectorWeights"
         ],
         "title": "FundItem"
       },
@@ -967,6 +975,24 @@
           "data"
         ],
         "title": "QuoteListGetResponse"
+      },
+      "SectorWeight": {
+        "properties": {
+          "sector": {
+            "type": "string",
+            "title": "Sector"
+          },
+          "weight": {
+            "type": "number",
+            "title": "Weight"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sector",
+          "weight"
+        ],
+        "title": "SectorWeight"
       },
       "StockItem": {
         "properties": {

--- a/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_fund_data.py
+++ b/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_fund_data.py
@@ -22,10 +22,22 @@ mock_fund_data = {
             "changePercent": 0.28,
         },
     },
-    "sectorWeights": {
-        "technology": 0.95,
-        "communication_services": 0.02,
-        "energy": 0.02,
-        "financial_services": 0.01,
-    }
+    "sectorWeights": [
+        {
+            "sector": "technology", 
+            "weight": 0.95
+        },
+        {
+            "sector": "communication_services", 
+            "weight": 0.02
+        },
+        {
+            "sector": "energy", 
+            "weight": 0.02
+        },
+        {
+            "sector": "financial_services", 
+            "weight": 0.01
+        }
+    ]
 }

--- a/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_fund_data.py
+++ b/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_fund_data.py
@@ -28,7 +28,7 @@ mock_fund_data = {
             "weight": 0.95
         },
         {
-            "sector": "communication_services", 
+            "sector": "communications", 
             "weight": 0.02
         },
         {
@@ -36,7 +36,7 @@ mock_fund_data = {
             "weight": 0.02
         },
         {
-            "sector": "financial_services", 
+            "sector": "financial", 
             "weight": 0.01
         }
     ]

--- a/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_fund_data.py
+++ b/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_fund_data.py
@@ -21,5 +21,11 @@ mock_fund_data = {
             "change": 1.25,
             "changePercent": 0.28,
         },
+    },
+    "sectorWeights": {
+        "technology": 0.95,
+        "communication_services": 0.02,
+        "energy": 0.02,
+        "financial_services": 0.01,
     }
 }

--- a/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_yfinance_fund_info.py
+++ b/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_yfinance_fund_info.py
@@ -1,4 +1,4 @@
-mock_yfinance_fund_data = {
+mock_yfinance_fund_info = {
     "shortName": "S&P 500 ETF fund",
     "longName": "Standard & Poorer 500 ETF Fund",
     "symbol": "SP500",

--- a/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_yfinance_fund_sector_weightings.py
+++ b/apps/api/stratify-data-api/src/routes/funds/_mocks/mock_yfinance_fund_sector_weightings.py
@@ -1,0 +1,14 @@
+
+mock_fund_sector_weightings = {
+    "realestate": 0.0,
+    "consumer_cyclical": 0.0,
+    "basic_materials": 0.0,
+    "consumer_defensive": 0.0,
+    "technology": 0.95,
+    "communication_services": 0.02,
+    "financial_services": 0.01,
+    "utilities": 0.0,
+    "industrials": 0.0,
+    "energy": 0.02,
+    "healthcare": 0.0
+}

--- a/apps/api/stratify-data-api/src/routes/funds/funds_get.py
+++ b/apps/api/stratify-data-api/src/routes/funds/funds_get.py
@@ -5,7 +5,14 @@ from yfinance import Tickers
 from pydantic import BaseModel
 from typing import List
 
-def format_fund_info(ticker_info) -> FundItem:
+def format_fund_info(ticker_info, sector_weights) -> FundItem:
+    formatted_sector_weights = dict[str, float]()
+    
+    for sector in sector_weights:
+        weight = sector_weights[sector]
+        if (weight > 0):
+            formatted_sector_weights[sector] = weight
+    
     return {
         "shortName": ticker_info.get("shortName"),
         "longName": ticker_info.get("longName"),
@@ -29,7 +36,8 @@ def format_fund_info(ticker_info) -> FundItem:
                 "change": ticker_info.get("regularMarketChange"),
                 "changePercent": ticker_info.get("regularMarketChangePercent"),
             },
-        }
+        },
+        "sectorWeights": formatted_sector_weights
     }
     
 class FundsGetResponse(BaseModel):
@@ -61,12 +69,13 @@ async def get_funds(
             
             for ticker in tickers:
                 ticker_data = tickers[ticker].info
+                sector_weights = tickers[ticker].funds_data.sector_weightings
                 
                 if not ticker_data or ticker_data.get("quoteType") == "NONE":
                     print(f"No info found for ticker: {ticker}")
                     continue
                 
-                formatted_funds.append(format_fund_info(ticker_data))
+                formatted_funds.append(format_fund_info(ticker_data, sector_weights))
                 
             if not formatted_funds or len(formatted_funds) == 0:
                 raise HTTPException(status_code=404, detail="No fund data found for provided symbols")

--- a/apps/api/stratify-data-api/src/routes/funds/funds_get.py
+++ b/apps/api/stratify-data-api/src/routes/funds/funds_get.py
@@ -5,14 +5,29 @@ from yfinance import Tickers
 from pydantic import BaseModel
 from typing import List
 
+sector_mapping = {
+    "basic_materials": "basicMaterials",
+    "communication_services": "communications",
+    "consumer_cyclical": "cyclical",
+    "consumer_defensive": "defense",
+    "energy": "energy",
+    "financial_services": "financial",
+    "healthcare": "healthcare",
+    "technology": "technology",
+    "industrials": "industrial",
+    "utilities": "utilities",
+    "real_estate": "realEstate",
+}
+
 def format_fund_info(ticker_info, sector_weights) -> FundItem:
     formatted_sector_weights = []
     
     for sector in sector_weights:
         weight = sector_weights[sector]
+        sector_name = sector_mapping.get(sector, sector)
         
         if (weight > 0):
-            formatted_sector_weights.append(SectorWeight(sector=sector, weight=weight))
+            formatted_sector_weights.append(SectorWeight(sector=sector_name, weight=weight))
     
     return {
         "shortName": ticker_info.get("shortName"),

--- a/apps/api/stratify-data-api/src/routes/funds/funds_get.py
+++ b/apps/api/stratify-data-api/src/routes/funds/funds_get.py
@@ -1,4 +1,4 @@
-from src.routes.funds.funds_schema import FundItem
+from src.routes.funds.funds_schema import FundItem, SectorWeight
 from src.utils.clean_symbol import clean_symbol
 from fastapi import APIRouter, Query, HTTPException
 from yfinance import Tickers
@@ -6,12 +6,13 @@ from pydantic import BaseModel
 from typing import List
 
 def format_fund_info(ticker_info, sector_weights) -> FundItem:
-    formatted_sector_weights = dict[str, float]()
+    formatted_sector_weights = []
     
     for sector in sector_weights:
         weight = sector_weights[sector]
+        
         if (weight > 0):
-            formatted_sector_weights[sector] = weight
+            formatted_sector_weights.append(SectorWeight(sector=sector, weight=weight))
     
     return {
         "shortName": ticker_info.get("shortName"),
@@ -37,7 +38,7 @@ def format_fund_info(ticker_info, sector_weights) -> FundItem:
                 "changePercent": ticker_info.get("regularMarketChangePercent"),
             },
         },
-        "sectorWeights": formatted_sector_weights
+        "sectorWeights": sorted(formatted_sector_weights, key=lambda x: x.weight, reverse=True)
     }
     
 class FundsGetResponse(BaseModel):

--- a/apps/api/stratify-data-api/src/routes/funds/funds_get_test.py
+++ b/apps/api/stratify-data-api/src/routes/funds/funds_get_test.py
@@ -1,12 +1,13 @@
 from unittest.mock import MagicMock
 from src.tests.mock_app import mock_app
-from src.routes.funds._mocks.mock_yfinance_fund_data import mock_yfinance_fund_data
+from src.routes.funds._mocks.mock_yfinance_fund_info import mock_yfinance_fund_info
+from src.routes.funds._mocks.mock_yfinance_fund_sector_weightings import mock_fund_sector_weightings
 from src.routes.funds._mocks.mock_fund_data import mock_fund_data
 
 def test_get_funds_success(mock_app, mocker):
     mock_tickers = MagicMock(tickers={
-        "SP500": MagicMock(info=mock_yfinance_fund_data),
-        "FTSE100": MagicMock(info=mock_yfinance_fund_data)
+        "SP500": MagicMock(info=mock_yfinance_fund_info, funds_data=MagicMock(sector_weightings=mock_fund_sector_weightings)),
+        "FTSE100": MagicMock(info=mock_yfinance_fund_info, funds_data=MagicMock(sector_weightings=mock_fund_sector_weightings))
     })
     
     mocker.patch("src.routes.funds.funds_get.Tickers", return_value=mock_tickers)

--- a/apps/api/stratify-data-api/src/routes/funds/funds_schema.py
+++ b/apps/api/stratify-data-api/src/routes/funds/funds_schema.py
@@ -1,5 +1,10 @@
 from src.utils.common_schemas import PriceDetails, ExchangeDetails
 from pydantic import BaseModel
+from typing import List
+
+class SectorWeight(BaseModel):
+    sector: str
+    weight: float
 
 class FundItem(BaseModel):
     shortName: str
@@ -11,4 +16,4 @@ class FundItem(BaseModel):
     currency: str
     exchange: ExchangeDetails
     priceDetails: PriceDetails
-    sectorWeights: dict[str, float]
+    sectorWeights: List[SectorWeight]

--- a/apps/api/stratify-data-api/src/routes/funds/funds_schema.py
+++ b/apps/api/stratify-data-api/src/routes/funds/funds_schema.py
@@ -11,3 +11,4 @@ class FundItem(BaseModel):
     currency: str
     exchange: ExchangeDetails
     priceDetails: PriceDetails
+    sectorWeights: dict[str, float]

--- a/apps/api/stratify-data-api/src/routes/funds/symbol/fund_symbol_get.py
+++ b/apps/api/stratify-data-api/src/routes/funds/symbol/fund_symbol_get.py
@@ -14,12 +14,15 @@ fund_symbol_get = APIRouter()
 async def get_fund(symbol: str) -> FundSymbolGetResponse:
     try:
         cleaned_symbol = clean_symbol(symbol)
-        fund_data = Ticker(cleaned_symbol).info
+        ticker = Ticker(cleaned_symbol)
+        fund_data = ticker.info
+        sector_weights = ticker.funds_data.sector_weightings
         
         if not fund_data or fund_data.get("quoteType") == "NONE":
             raise HTTPException(status_code=404, detail=f"No data found for symbol: {symbol}")
         
-        formatted_data = format_fund_info(fund_data)
+        formatted_data = format_fund_info(fund_data, sector_weights)
+        
         
         return FundSymbolGetResponse(data=formatted_data)
     except HTTPException:

--- a/apps/api/stratify-data-api/src/routes/funds/symbol/fund_symbol_get_test.py
+++ b/apps/api/stratify-data-api/src/routes/funds/symbol/fund_symbol_get_test.py
@@ -1,10 +1,11 @@
 from unittest.mock import MagicMock
 from src.tests.mock_app import mock_app
-from src.routes.funds._mocks.mock_yfinance_fund_data import mock_yfinance_fund_data
+from src.routes.funds._mocks.mock_yfinance_fund_info import mock_yfinance_fund_info
+from src.routes.funds._mocks.mock_yfinance_fund_sector_weightings import mock_fund_sector_weightings
 from src.routes.funds._mocks.mock_fund_data import mock_fund_data
 
 def test_get_fund_success(mock_app, mocker):
-    mock_ticker = MagicMock(info=mock_yfinance_fund_data)
+    mock_ticker = MagicMock(info=mock_yfinance_fund_info, funds_data=MagicMock(sector_weightings=mock_fund_sector_weightings))
     
     mocker.patch("src.routes.funds.symbol.fund_symbol_get.Ticker", return_value=mock_ticker)
 

--- a/apps/api/stratify-data-api/src/routes/stocks/_mocks/mock_stock_data.py
+++ b/apps/api/stratify-data-api/src/routes/stocks/_mocks/mock_stock_data.py
@@ -7,7 +7,7 @@ mock_stock_data = {
     "marketCap": 3000000000000,
     "industryDetails": {
         "industry": "Consumer Electronics",
-        "sector": "Technology"
+        "sector": "technology"
     },
     "priceDetails": {
         "currentPrice": 150.25,

--- a/apps/api/stratify-data-api/src/routes/stocks/stocks_get.py
+++ b/apps/api/stratify-data-api/src/routes/stocks/stocks_get.py
@@ -5,6 +5,20 @@ from yfinance import Tickers
 from pydantic import BaseModel
 from typing import List
 
+sector_mapping = {
+    "Basic Materials": "basicMaterials",
+    "Communication Services": "communications",
+    "Consumer Cyclical": "cyclical",
+    "Consumer Defensive": "defense",
+    "Energy": "energy",
+    "Financial Services": "financial",
+    "Healthcare": "healthcare",
+    "Technology": "technology",
+    "Industrials": "industrial",
+    "Utilities": "utilities",
+    "Real Estate": "realEstate",
+}
+
 class StocksGetResponse(BaseModel):
     data: List[StockItem]
 
@@ -18,7 +32,7 @@ def format_stock_info(ticker_info) -> StockItem:
         "marketCap": ticker_info.get("marketCap"),
         "industryDetails": {
             "industry": ticker_info.get("industry"),
-            "sector": ticker_info.get("sector"),
+            "sector": sector_mapping.get(ticker_info.get("sector"), "other")
         },
         "priceDetails": {
             "currentPrice": ticker_info.get("regularMarketPrice"),

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationCard.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationCard.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithContext } from "@/app/tests/utils";
+import { screen } from "@testing-library/react";
+import { TooltipProvider } from "@/app/components/ui/tooltip";
+import MockSessionProvider from "@/app/tests/_mocks/MockSessionProvider";
+import AssetAllocationCard from "./AssetAllocationCard";
+import { mockInvestmentsData } from "../InvestmentsTable/_mocks/mockInvestmentData";
+
+const mockUseInvestmentsList = vi.fn();
+
+vi.mock("./useInvestmentsList", () => ({
+    useInvestmentsList: () => mockUseInvestmentsList(),
+}));
+
+describe("AssetAllocationCard", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const renderComponent = () => {
+        renderWithContext({
+            children: (
+                <TooltipProvider>
+                    <MockSessionProvider>
+                        <AssetAllocationCard portfolioId={1} />
+                    </MockSessionProvider>
+                </TooltipProvider>
+            ),
+        });
+    };
+
+    it("should render the card successfully", async () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: mockInvestmentsData,
+            isLoading: false,
+        });
+
+        renderComponent();
+
+        expect(screen.getByText("Asset Allocation")).toBeInTheDocument();
+        expect(screen.getByText("Group by:")).toBeInTheDocument();
+        expect(screen.getByTestId("group-by-select-value")).toBeInTheDocument();
+        expect(
+            await screen.findByTestId("asset-allocation-chart"),
+        ).toBeInTheDocument();
+    });
+
+    it("should disable the group by selector if there are no current investments", async () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: [],
+            isLoading: false,
+        });
+
+        renderComponent();
+
+        expect(
+            await screen.findByTestId("group-by-select-disabled"),
+        ).toBeInTheDocument();
+    });
+
+    it("should disable the group by selector when data is loading", async () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: [],
+            isLoading: true,
+        });
+
+        renderComponent();
+
+        expect(
+            await screen.findByTestId("group-by-select-disabled"),
+        ).toBeInTheDocument();
+    });
+
+    it("should show the loading skeleton when data is loading", async () => {
+        mockUseInvestmentsList.mockReturnValue({
+            data: [],
+            isLoading: true,
+        });
+
+        renderComponent();
+
+        expect(
+            await screen.findByTestId("pie-chart-skeleton"),
+        ).toBeInTheDocument();
+    });
+});

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationCard.tsx
@@ -5,43 +5,9 @@ import {
 } from "@/app/components/ui/tooltip";
 import { useInvestmentsList } from "../InvestmentsTable/useInvestmentsList";
 import { InfoIcon } from "lucide-react";
-import {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/app/components/ui/select";
 import { useState } from "react";
-
-const groupByValues = [
-    "assetClass",
-    "sector",
-    "country",
-    "noGrouping",
-] as const;
-
-type GroupByOption = (typeof groupByValues)[number];
-
-const groupByOptions = [
-    {
-        label: "Asset class",
-        value: "assetClass",
-    },
-    {
-        label: "Sector",
-        value: "sector",
-    },
-    {
-        label: "Country",
-        value: "country",
-    },
-    {
-        label: "No grouping",
-        value: "noGrouping",
-    },
-];
+import GroupBySelector, { GroupByOption } from "./GroupBySelector";
+import AssetAllocationChart from "./AssetAllocationChart";
 
 interface AssetAllocationCardProps {
     portfolioId: number | null;
@@ -51,8 +17,12 @@ const AssetAllocationCard = ({ portfolioId }: AssetAllocationCardProps) => {
     const { data, isLoading } = useInvestmentsList(portfolioId);
     const [groupBy, setGroupBy] = useState<GroupByOption>("assetClass");
 
+    const filteredData = data.filter(
+        (investment) => investment.currentValue > 0,
+    );
+
     return (
-        <div className="flex-1 h-full py-2.5 px-3 bg-secondary-lightest border border-primary-dark rounded-xl font-sans">
+        <div className="flex flex-col h-full py-2.5 px-3 bg-secondary-lightest border border-primary-dark rounded-xl font-sans">
             <div className="flex flex-row gap-x-1 text-xl font-medium text-primary-darker">
                 <div>Asset Allocation</div>
                 <Tooltip>
@@ -67,43 +37,16 @@ const AssetAllocationCard = ({ portfolioId }: AssetAllocationCardProps) => {
                     </TooltipTrigger>
                 </Tooltip>
             </div>
-            <div className="mt-2">
-                <div className="text-base leading-5 text-secondary-base mb-1">
-                    Group by:
-                </div>
-                <Select
-                    value={groupBy}
-                    onValueChange={(value) =>
-                        setGroupBy(value as GroupByOption)
-                    }
-                    disabled={data.length === 0 || isLoading === true}
-                >
-                    <SelectTrigger
-                        className="max-w-36 border-secondary-dark bg-secondary-lighter text-secondary-dark ring-secondary-dark"
-                        iconClassName="text-secondary-dark"
-                    >
-                        <SelectValue data-testid="group-by-select-value" />
-                    </SelectTrigger>
-                    <SelectContent
-                        className="border-secondary-base bg-secondary-lightest text-secondary-dark"
-                        side="bottom"
-                        align="start"
-                    >
-                        <SelectGroup className="flex flex-col gap-y-1">
-                            {groupByOptions.map((option) => (
-                                <SelectItem
-                                    className="data-highlighted:bg-secondary-lighter data-[state=checked]:bg-secondary-light data-[state=checked]:text-secondary-darkest text-secondary-dark cursor-pointer"
-                                    iconClassName="text-secondary-dark"
-                                    key={option.value}
-                                    value={option.value}
-                                >
-                                    {option.label}
-                                </SelectItem>
-                            ))}
-                        </SelectGroup>
-                    </SelectContent>
-                </Select>
-            </div>
+            <GroupBySelector
+                groupBy={groupBy}
+                setGroupBy={setGroupBy}
+                disabled={isLoading || filteredData.length === 0}
+            />
+            <AssetAllocationChart
+                data={filteredData}
+                groupBy={groupBy}
+                isLoading={isLoading}
+            />
         </div>
     );
 };

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationCard.tsx
@@ -1,0 +1,111 @@
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/app/components/ui/tooltip";
+import { useInvestmentsList } from "../InvestmentsTable/useInvestmentsList";
+import { InfoIcon } from "lucide-react";
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/app/components/ui/select";
+import { useState } from "react";
+
+const groupByValues = [
+    "assetClass",
+    "sector",
+    "country",
+    "noGrouping",
+] as const;
+
+type GroupByOption = (typeof groupByValues)[number];
+
+const groupByOptions = [
+    {
+        label: "Asset class",
+        value: "assetClass",
+    },
+    {
+        label: "Sector",
+        value: "sector",
+    },
+    {
+        label: "Country",
+        value: "country",
+    },
+    {
+        label: "No grouping",
+        value: "noGrouping",
+    },
+];
+
+interface AssetAllocationCardProps {
+    portfolioId: number | null;
+}
+
+const AssetAllocationCard = ({ portfolioId }: AssetAllocationCardProps) => {
+    const { data, isLoading } = useInvestmentsList(portfolioId);
+    const [groupBy, setGroupBy] = useState<GroupByOption>("assetClass");
+
+    return (
+        <div className="flex-1 h-full py-2.5 px-3 bg-secondary-lightest border border-primary-dark rounded-xl font-sans">
+            <div className="flex flex-row gap-x-1 text-xl font-medium text-primary-darker">
+                <div>Asset Allocation</div>
+                <Tooltip>
+                    <TooltipTrigger>
+                        <InfoIcon className="w-4 h-4 text-primary-darker" />
+                        <TooltipContent
+                            className="bg-secondary-lighter text-secondary-dark"
+                            arrowClassName="bg-secondary-lighter fill-secondary-lighter"
+                        >
+                            <p className="text-sm">Asset allocation tooltip</p>
+                        </TooltipContent>
+                    </TooltipTrigger>
+                </Tooltip>
+            </div>
+            <div className="mt-2">
+                <div className="text-base leading-5 text-secondary-base mb-1">
+                    Group by:
+                </div>
+                <Select
+                    value={groupBy}
+                    onValueChange={(value) =>
+                        setGroupBy(value as GroupByOption)
+                    }
+                    disabled={data.length === 0 || isLoading === true}
+                >
+                    <SelectTrigger
+                        className="max-w-36 border-secondary-dark bg-secondary-lighter text-secondary-dark ring-secondary-dark"
+                        iconClassName="text-secondary-dark"
+                    >
+                        <SelectValue data-testid="group-by-select-value" />
+                    </SelectTrigger>
+                    <SelectContent
+                        className="border-secondary-base bg-secondary-lightest text-secondary-dark"
+                        side="bottom"
+                        align="start"
+                    >
+                        <SelectGroup className="flex flex-col gap-y-1">
+                            {groupByOptions.map((option) => (
+                                <SelectItem
+                                    className="data-highlighted:bg-secondary-lighter data-[state=checked]:bg-secondary-light data-[state=checked]:text-secondary-darkest text-secondary-dark cursor-pointer"
+                                    iconClassName="text-secondary-dark"
+                                    key={option.value}
+                                    value={option.value}
+                                >
+                                    {option.label}
+                                </SelectItem>
+                            ))}
+                        </SelectGroup>
+                    </SelectContent>
+                </Select>
+            </div>
+        </div>
+    );
+};
+
+export default AssetAllocationCard;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.test.tsx
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithContext } from "@/app/tests/utils";
+import { screen, waitFor } from "@testing-library/react";
+import AssetAllocationChart, {
+    AssetAllocationChartProps,
+} from "./AssetAllocationChart";
+import { mockInvestmentsData } from "../InvestmentsTable/_mocks/mockInvestmentData";
+import MockSessionProvider from "@/app/tests/_mocks/MockSessionProvider";
+
+const defaultProps = {
+    data: mockInvestmentsData,
+    groupBy: "assetClass",
+    isLoading: false,
+} satisfies AssetAllocationChartProps;
+
+describe("AssetAllocationChart", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const renderComponent = (props?: Partial<AssetAllocationChartProps>) => {
+        renderWithContext({
+            children: (
+                <MockSessionProvider>
+                    <AssetAllocationChart {...defaultProps} {...props} />
+                </MockSessionProvider>
+            ),
+        });
+    };
+
+    it("should render the chart successfully", async () => {
+        renderComponent();
+
+        expect(
+            await screen.findByTestId("asset-allocation-chart"),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId("toggle-legend-button")).toBeInTheDocument();
+    });
+
+    it("should show the loading state when isLoading is true", async () => {
+        renderComponent({ isLoading: true });
+
+        expect(
+            await screen.findByTestId("pie-chart-skeleton"),
+        ).toBeInTheDocument();
+    });
+
+    it("should display the legend when the toggle button is clicked", async () => {
+        renderComponent();
+
+        const toggleButton = await screen.findByTestId("toggle-legend-button");
+        expect(
+            screen.queryByTestId("asset-allocation-legend"),
+        ).not.toBeInTheDocument();
+
+        toggleButton.click();
+        expect(
+            await screen.findByTestId("asset-allocation-legend"),
+        ).toBeInTheDocument();
+    });
+
+    it("should display different text on the toggle if the legend is visible", async () => {
+        renderComponent();
+
+        const toggleButton = await screen.findByTestId("toggle-legend-button");
+        expect(toggleButton).toHaveTextContent("View Legend");
+
+        toggleButton.click();
+
+        await waitFor(() => {
+            expect(toggleButton).toHaveTextContent("View Pie Chart");
+        });
+    });
+});

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
@@ -2,16 +2,13 @@ import { useMemo, useState } from "react";
 import { AssetType } from "../../markets/MarketDataTable/MarketDataTable";
 import { Investment } from "../InvestmentsTable/InvestmentsTable";
 import { GroupByOption } from "./GroupBySelector";
-import { Label, Pie, PieChart } from "recharts";
-import {
-    ChartConfig,
-    ChartContainer,
-    ChartTooltip,
-} from "@/app/components/ui/chart";
+import { Label, Pie, PieChart, ResponsiveContainer } from "recharts";
+import { ChartTooltip } from "@/app/components/ui/chart";
 import { placeholderData } from "./placeholderChartData";
 import PieChartSkeleton from "./PieChartSkeleton";
 import { useSessionContext } from "../../SessionProvider";
 import { Button } from "@/app/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const colourVars = [
     "var(--primary-base)",
@@ -63,13 +60,17 @@ export interface ChartDataItem {
 
 interface CustomLegendProps {
     data: ChartDataItem[];
-    isLegendVisible: boolean;
+    groupBy: GroupByOption;
 }
 
-const CustomLegend = ({ data, isLegendVisible }: CustomLegendProps) => {
+const CustomLegend = ({ data, groupBy }: CustomLegendProps) => {
     return (
         <div
-            className={`flex flex-col font-sans justify-items-start text-secondary-dark w-full mt-5 gap-y-1 ${isLegendVisible ? "" : "hidden"}`}
+            className={cn(
+                "flex flex-col font-sans justify-items-start text-secondary-dark w-full mt-5 gap-y-1",
+                groupBy !== "assetClass" && "grid grid-cols-2",
+            )}
+            data-testid="asset-allocation-legend"
         >
             {data.map((item) => (
                 <div
@@ -155,7 +156,7 @@ const CustomTooltip = ({
     );
 };
 
-interface AssetAllocationChartProps {
+export interface AssetAllocationChartProps {
     data: Investment[];
     groupBy: GroupByOption;
     isLoading: boolean;
@@ -281,44 +282,6 @@ const AssetAllocationChart = ({
         };
     }, [data]);
 
-    const chartConfig = {
-        assetClass: {
-            STOCK: {
-                label: assetClasses["STOCK"].label,
-                color: assetClasses["STOCK"].colour,
-            },
-            CRYPTOCURRENCY: {
-                label: assetClasses["CRYPTOCURRENCY"].label,
-                color: assetClasses["CRYPTOCURRENCY"].colour,
-            },
-            ETF: {
-                label: assetClasses["ETF"].label,
-                color: assetClasses["ETF"].colour,
-            },
-        },
-        country: groupedData.country.reduce((acc, { label }) => {
-            acc[label] = {
-                label: `Country ${label}`,
-                color: "var(--primary-base)",
-            };
-            return acc;
-        }, {} as ChartConfig),
-        sector: groupedData.sector.reduce((acc, { label }) => {
-            acc[label] = {
-                label,
-                color: "var(--primary-base)",
-            };
-            return acc;
-        }, {} as ChartConfig),
-        noGrouping: groupedData.noGrouping.reduce((acc, { label }) => {
-            acc[label] = {
-                label,
-                color: "var(--primary-base)",
-            };
-            return acc;
-        }, {} as ChartConfig),
-    };
-
     const selectedGroupData =
         data.length > 0 ? groupedData[groupBy] : placeholderData;
 
@@ -329,13 +292,16 @@ const AssetAllocationChart = ({
     return isLoading ? (
         <PieChartSkeleton />
     ) : (
-        <>
-            <ChartContainer
-                config={chartConfig[groupBy]}
-                className={`mx-auto aspect-square min-h-62.5 max-w-62.5 mt-2 items-center ${isLegendVisible ? "hidden" : ""}`}
-                data-testid="asset-allocation-chart"
+        <div
+            className="flex flex-col items-center w-full"
+            data-testid="asset-allocation-chart"
+        >
+            <ResponsiveContainer
+                width="100%"
+                height={250}
+                className={`${isLegendVisible ? "hidden" : ""}`}
             >
-                <PieChart width={500} height={500} responsive>
+                <PieChart>
                     {data.length > 0 ? (
                         <ChartTooltip
                             cursor={false}
@@ -412,7 +378,9 @@ const AssetAllocationChart = ({
                                                             32
                                                         }
                                                     >
-                                                        {"assets"}
+                                                        {data.length === 1
+                                                            ? "asset"
+                                                            : "assets"}
                                                     </tspan>
                                                 </>
                                             )}
@@ -423,23 +391,26 @@ const AssetAllocationChart = ({
                         />
                     </Pie>
                 </PieChart>
-            </ChartContainer>
+            </ResponsiveContainer>
             {data.length > 0 ? (
                 <>
-                    <CustomLegend
-                        data={selectedGroupData}
-                        isLegendVisible={isLegendVisible}
-                    />
+                    {isLegendVisible && (
+                        <CustomLegend
+                            data={selectedGroupData}
+                            groupBy={groupBy}
+                        />
+                    )}
                     <Button
                         variant="secondary"
-                        className="mt-5"
+                        className="mt-5 w-full"
                         onClick={() => setIsLegendVisible(!isLegendVisible)}
+                        data-testid="toggle-legend-button"
                     >
                         {isLegendVisible ? "View Pie Chart" : "View Legend"}
                     </Button>
                 </>
             ) : null}
-        </>
+        </div>
     );
 };
 

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
@@ -324,6 +324,8 @@ const AssetAllocationChart = ({
                         innerRadius={85}
                         outerRadius={110}
                         paddingAngle={selectedGroupData.length > 1 ? 3 : 0}
+                        strokeWidth={selectedGroupData.length > 1 ? 0.5 : 0}
+                        stroke="var(--secondary-lightest)"
                         cx="50%"
                         cy="50%"
                     >

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
@@ -333,6 +333,7 @@ const AssetAllocationChart = ({
             <ChartContainer
                 config={chartConfig[groupBy]}
                 className={`mx-auto aspect-square min-h-62.5 max-w-62.5 mt-2 items-center ${isLegendVisible ? "hidden" : ""}`}
+                data-testid="asset-allocation-chart"
             >
                 <PieChart width={500} height={500} responsive>
                     {data.length > 0 ? (

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/AssetAllocationChart.tsx
@@ -1,0 +1,445 @@
+import { useMemo, useState } from "react";
+import { AssetType } from "../../markets/MarketDataTable/MarketDataTable";
+import { Investment } from "../InvestmentsTable/InvestmentsTable";
+import { GroupByOption } from "./GroupBySelector";
+import { Label, Pie, PieChart } from "recharts";
+import {
+    ChartConfig,
+    ChartContainer,
+    ChartTooltip,
+} from "@/app/components/ui/chart";
+import { placeholderData } from "./placeholderChartData";
+import PieChartSkeleton from "./PieChartSkeleton";
+import { useSessionContext } from "../../SessionProvider";
+import { Button } from "@/app/components/ui/button";
+
+const colourVars = [
+    "var(--primary-base)",
+    "var(--secondary-base)",
+    "var(--accent-base)",
+    "var(--positive-base)",
+    "var(--negative-base)",
+    "var(--primary-dark)",
+    "var(--secondary-dark)",
+    "var(--accent-dark)",
+    "var(--primary-darker)",
+    "var(--secondary-darker)",
+    "var(--accent-darker)",
+    "var(--primary-darkest)",
+    "var(--secondary-darkest)",
+    "var(--accent-darkest)",
+];
+
+interface AssetClassConfig {
+    label: string;
+    colour: string;
+}
+
+const assetClasses = {
+    STOCK: {
+        label: "Stock",
+        colour: "var(--secondary-base)",
+    },
+    CRYPTOCURRENCY: {
+        label: "Cryptocurrency",
+        colour: "var(--accent-base)",
+    },
+    ETF: {
+        label: "Exchange traded fund",
+        colour: "var(--primary-base)",
+    },
+} as Record<AssetType, AssetClassConfig>;
+
+export interface ChartDataItem {
+    label: string | number;
+    currentValue: number;
+    absoluteReturn: number;
+    percentageReturn: number;
+    assetCount: number;
+    fill: string;
+    sector?: string;
+    countryId?: number;
+}
+
+interface CustomLegendProps {
+    data: ChartDataItem[];
+    isLegendVisible: boolean;
+}
+
+const CustomLegend = ({ data, isLegendVisible }: CustomLegendProps) => {
+    return (
+        <div
+            className={`flex flex-col font-sans justify-items-start text-secondary-dark w-full mt-5 gap-y-1 ${isLegendVisible ? "" : "hidden"}`}
+        >
+            {data.map((item) => (
+                <div
+                    key={item.label}
+                    className="flex items-center gap-2 text-base"
+                >
+                    <div
+                        className="h-3 w-3 shrink-0 rounded-full"
+                        style={{ backgroundColor: item.fill }}
+                    />
+                    {item.label}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+interface ChartTooltipContentProps {
+    active: boolean;
+    groupBy: GroupByOption;
+    data: ChartDataItem;
+    totalPortfolioValue: number;
+    currency: string;
+}
+
+const CustomTooltip = ({
+    active,
+    groupBy,
+    data,
+    totalPortfolioValue,
+    currency,
+}: ChartTooltipContentProps) => {
+    if (!active || !data) return null;
+
+    const portfolioAllocationPercentage = (
+        (data.currentValue / totalPortfolioValue) *
+        100
+    ).toFixed(2);
+
+    return (
+        <div className="flex flex-col items-start gap-y-1 bg-secondary-lightest border border-secondary-dark rounded-md py-1 px-2 font-sans text-secondary-base font-medium">
+            <div className="font-semibold text-base text-secondary-dark text-nowrap">
+                {data.label}
+            </div>
+            {groupBy === "noGrouping" ? (
+                <div className="flex flex-col text-sm w-full">
+                    <div className="flex flex-row justify-between gap-x-2">
+                        {"Country"}
+                        <div>{data?.countryId}</div>
+                    </div>
+                    <div className="flex flex-row justify-between gap-x-2">
+                        {"Sector"}
+                        <div>{data?.sector}</div>
+                    </div>
+                    <div className="flex flex-row justify-between gap-x-2">
+                        {"Portfolio allocation"}
+                        <div>{`${portfolioAllocationPercentage}%`}</div>
+                    </div>
+                </div>
+            ) : (
+                <div className="flex flex-col text-sm w-full">
+                    <div className="flex flex-row justify-between gap-x-2">
+                        {"Number of assets"}
+                        <div>{data.assetCount}</div>
+                    </div>
+                    <div className="flex flex-row justify-between gap-x-2">
+                        {"Portfolio allocation"}
+                        <div>{`${portfolioAllocationPercentage}%`}</div>
+                    </div>
+                    <div className="flex flex-row justify-between gap-x-2">
+                        {`Return (${currency})`}
+                        <div
+                            className={`${data.currentValue > 0 ? "text-positive-base" : "text-negative-base"}`}
+                        >
+                            {data.currentValue > 0
+                                ? `+ ${data.absoluteReturn.toLocaleString()}`
+                                : data.absoluteReturn.toLocaleString()}
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+interface AssetAllocationChartProps {
+    data: Investment[];
+    groupBy: GroupByOption;
+    isLoading: boolean;
+}
+
+const AssetAllocationChart = ({
+    data,
+    groupBy,
+    isLoading,
+}: AssetAllocationChartProps) => {
+    const { session } = useSessionContext();
+    const userCurrency = session?.userDetails.currency;
+
+    const [isLegendVisible, setIsLegendVisible] = useState<boolean>(false);
+
+    const groupedData = useMemo(() => {
+        const assetClass = data.reduce((acc, investment) => {
+            const assetTypeConfig = assetClasses[investment.type];
+
+            const existingItem = acc.find(
+                (item) => item.label === assetTypeConfig.label,
+            );
+
+            if (existingItem) {
+                existingItem.currentValue += investment.currentValue;
+                existingItem.absoluteReturn += investment.currentReturn;
+                existingItem.percentageReturn +=
+                    investment.currentReturnPercentage;
+                existingItem.assetCount += 1;
+            } else {
+                acc.push({
+                    label: assetTypeConfig.label,
+                    currentValue: investment.currentValue,
+                    fill: assetTypeConfig.colour,
+                    absoluteReturn: investment.currentReturn,
+                    percentageReturn: investment.currentReturnPercentage,
+                    assetCount: 1,
+                });
+            }
+
+            return acc;
+        }, [] as ChartDataItem[]);
+
+        const country = data.reduce((acc, investment) => {
+            const countryId = investment.assetCountryId;
+
+            const existingItem = acc.find((item) => item.label === countryId);
+
+            if (existingItem) {
+                existingItem.currentValue += investment.currentValue;
+                existingItem.absoluteReturn += investment.currentReturn;
+                existingItem.percentageReturn +=
+                    investment.currentReturnPercentage;
+                existingItem.assetCount += 1;
+            } else {
+                acc.push({
+                    label: countryId,
+                    currentValue: investment.currentValue,
+                    fill: colourVars[
+                        Object.keys(acc).length % colourVars.length
+                    ],
+                    absoluteReturn: investment.currentReturn,
+                    percentageReturn: investment.currentReturnPercentage,
+                    assetCount: 1,
+                });
+            }
+
+            return acc;
+        }, [] as ChartDataItem[]);
+
+        const sector = data.reduce((acc, investment) => {
+            investment.sectorDetails.forEach(({ sector, weight }) => {
+                const existingItem = acc.find((item) => item.label === sector);
+
+                if (existingItem) {
+                    existingItem.currentValue +=
+                        investment.currentValue * weight;
+                    existingItem.absoluteReturn +=
+                        investment.currentReturn * weight;
+                    existingItem.percentageReturn +=
+                        investment.currentReturnPercentage * weight;
+                    existingItem.assetCount += 1;
+                } else {
+                    acc.push({
+                        label: sector,
+                        currentValue: investment.currentValue * weight,
+                        fill: colourVars[
+                            Object.keys(acc).length % colourVars.length
+                        ],
+                        absoluteReturn: investment.currentReturn,
+                        percentageReturn: investment.currentReturnPercentage,
+                        assetCount: 1,
+                    });
+                }
+            });
+            return acc;
+        }, [] as ChartDataItem[]);
+
+        const noGrouping = data.reduce((acc, investment) => {
+            acc.push({
+                label: investment.name,
+                countryId: investment.assetCountryId,
+                sector: investment.sectorDetails[0].sector,
+                currentValue: investment.currentValue,
+                fill: colourVars[Object.keys(acc).length % colourVars.length],
+                absoluteReturn: investment.currentReturn,
+                percentageReturn: investment.currentReturnPercentage,
+                assetCount: 1,
+            });
+
+            return acc;
+        }, [] as ChartDataItem[]);
+
+        return {
+            assetClass: assetClass.sort(
+                (a, b) => b.currentValue - a.currentValue,
+            ),
+            country: country.sort((a, b) => b.currentValue - a.currentValue),
+            sector: sector.sort((a, b) => b.currentValue - a.currentValue),
+            noGrouping: noGrouping.sort(
+                (a, b) => b.currentValue - a.currentValue,
+            ),
+        };
+    }, [data]);
+
+    const chartConfig = {
+        assetClass: {
+            STOCK: {
+                label: assetClasses["STOCK"].label,
+                color: assetClasses["STOCK"].colour,
+            },
+            CRYPTOCURRENCY: {
+                label: assetClasses["CRYPTOCURRENCY"].label,
+                color: assetClasses["CRYPTOCURRENCY"].colour,
+            },
+            ETF: {
+                label: assetClasses["ETF"].label,
+                color: assetClasses["ETF"].colour,
+            },
+        },
+        country: groupedData.country.reduce((acc, { label }) => {
+            acc[label] = {
+                label: `Country ${label}`,
+                color: "var(--primary-base)",
+            };
+            return acc;
+        }, {} as ChartConfig),
+        sector: groupedData.sector.reduce((acc, { label }) => {
+            acc[label] = {
+                label,
+                color: "var(--primary-base)",
+            };
+            return acc;
+        }, {} as ChartConfig),
+        noGrouping: groupedData.noGrouping.reduce((acc, { label }) => {
+            acc[label] = {
+                label,
+                color: "var(--primary-base)",
+            };
+            return acc;
+        }, {} as ChartConfig),
+    };
+
+    const selectedGroupData =
+        data.length > 0 ? groupedData[groupBy] : placeholderData;
+
+    const totalPortfolioValue = data.reduce((sum, investment) => {
+        return sum + investment.currentValue;
+    }, 0);
+
+    return isLoading ? (
+        <PieChartSkeleton />
+    ) : (
+        <>
+            <ChartContainer
+                config={chartConfig[groupBy]}
+                className={`mx-auto aspect-square min-h-62.5 max-w-62.5 mt-2 items-center ${isLegendVisible ? "hidden" : ""}`}
+            >
+                <PieChart width={500} height={500} responsive>
+                    {data.length > 0 ? (
+                        <ChartTooltip
+                            cursor={false}
+                            animationEasing="ease"
+                            content={({ active, payload }) => (
+                                <CustomTooltip
+                                    active={active}
+                                    groupBy={groupBy}
+                                    data={payload[0]?.payload}
+                                    totalPortfolioValue={totalPortfolioValue}
+                                    currency={userCurrency!}
+                                />
+                            )}
+                        />
+                    ) : null}
+                    <Pie
+                        nameKey="label"
+                        dataKey="currentValue"
+                        data={selectedGroupData}
+                        innerRadius={85}
+                        outerRadius={110}
+                        paddingAngle={selectedGroupData.length > 1 ? 3 : 0}
+                        cx="50%"
+                        cy="50%"
+                    >
+                        <Label
+                            content={({ viewBox }) => {
+                                if (
+                                    viewBox &&
+                                    "cx" in viewBox &&
+                                    "cy" in viewBox
+                                ) {
+                                    return (
+                                        <text
+                                            x={viewBox.cx}
+                                            y={viewBox.cy}
+                                            textAnchor="middle"
+                                            dominantBaseline="middle"
+                                        >
+                                            {!isLoading && data.length === 0 ? (
+                                                <>
+                                                    <tspan
+                                                        className="font-sans font-medium text-lg fill-secondary-light"
+                                                        x={viewBox.cx}
+                                                        y={viewBox.cy}
+                                                    >
+                                                        {"No data"}
+                                                    </tspan>
+                                                    <tspan
+                                                        className="font-sans font-medium text-lg fill-secondary-light"
+                                                        x={viewBox.cx}
+                                                        y={
+                                                            (viewBox.cy || 0) +
+                                                            24
+                                                        }
+                                                    >
+                                                        {"Available"}
+                                                    </tspan>
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <tspan
+                                                        className="font-sans font-bold text-5xl leading-10 fill-secondary-base"
+                                                        x={viewBox.cx}
+                                                        y={viewBox.cy}
+                                                    >
+                                                        {data.length}
+                                                    </tspan>
+                                                    <tspan
+                                                        className="font-sans text-xl fill-secondary-base"
+                                                        x={viewBox.cx}
+                                                        y={
+                                                            (viewBox.cy || 0) +
+                                                            32
+                                                        }
+                                                    >
+                                                        {"assets"}
+                                                    </tspan>
+                                                </>
+                                            )}
+                                        </text>
+                                    );
+                                }
+                            }}
+                        />
+                    </Pie>
+                </PieChart>
+            </ChartContainer>
+            {data.length > 0 ? (
+                <>
+                    <CustomLegend
+                        data={selectedGroupData}
+                        isLegendVisible={isLegendVisible}
+                    />
+                    <Button
+                        variant="secondary"
+                        className="mt-5"
+                        onClick={() => setIsLegendVisible(!isLegendVisible)}
+                    >
+                        {isLegendVisible ? "View Pie Chart" : "View Legend"}
+                    </Button>
+                </>
+            ) : null}
+        </>
+    );
+};
+
+export default AssetAllocationChart;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/GroupBySelector.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/GroupBySelector.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MockPointerEvent } from "@/app/tests/_mocks/MockPointerEvent";
+import GroupBySelector, { GroupBySelectorProps } from "./GroupBySelector";
+
+const mockSetGroupBy = vi.fn();
+
+const defaultGroupBySelectorProps = {
+    groupBy: "assetClass",
+    setGroupBy: mockSetGroupBy,
+    disabled: false,
+} satisfies GroupBySelectorProps;
+
+describe("GroupBySelector", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const renderComponent = (props?: Partial<GroupBySelectorProps>) =>
+        render(<GroupBySelector {...defaultGroupBySelectorProps} {...props} />);
+
+    it("should render the group by selector", () => {
+        renderComponent();
+
+        expect(
+            screen.getByTestId("group-by-select-enabled"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Group by:")).toBeInTheDocument();
+        expect(screen.getByText("Asset Class")).toBeInTheDocument();
+    });
+
+    it("should be disabled when the disabled prop is true", () => {
+        renderComponent({ disabled: true });
+
+        expect(
+            screen.getByTestId("group-by-select-disabled"),
+        ).toBeInTheDocument();
+    });
+
+    it("should render the group by options when clicking on the selector", async () => {
+        renderComponent();
+
+        const selectButton = screen.getByText("Asset Class");
+
+        fireEvent.click(
+            selectButton,
+            new MockPointerEvent("pointerdown", { button: 0 }),
+        );
+
+        const groupByOptions = [
+            "Asset Class",
+            "Sector",
+            "Country",
+            "No Grouping",
+        ];
+
+        const groupByOptionsComponent =
+            await screen.findByTestId("group-by-options");
+
+        for (const option of groupByOptions) {
+            expect(
+                within(groupByOptionsComponent).getByText(option),
+            ).toBeInTheDocument();
+        }
+    });
+
+    it("should set the group by option when selecting an option", async () => {
+        renderComponent();
+
+        const selectButton = screen.getByText("Asset Class");
+
+        fireEvent.click(
+            selectButton,
+            new MockPointerEvent("pointerdown", { button: 0 }),
+        );
+
+        const sectorOption = await screen.findByText("Sector");
+
+        fireEvent.click(sectorOption);
+
+        expect(mockSetGroupBy).toHaveBeenCalledWith("sector");
+    });
+});

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/GroupBySelector.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/GroupBySelector.tsx
@@ -19,7 +19,7 @@ export type GroupByOption = (typeof groupByValues)[number];
 
 const groupByOptions = [
     {
-        label: "Asset class",
+        label: "Asset Class",
         value: "assetClass",
     },
     {
@@ -31,12 +31,12 @@ const groupByOptions = [
         value: "country",
     },
     {
-        label: "No grouping",
+        label: "No Grouping",
         value: "noGrouping",
     },
 ];
 
-interface GroupBySelectorProps {
+export interface GroupBySelectorProps {
     groupBy: GroupByOption;
     setGroupBy: Dispatch<SetStateAction<GroupByOption>>;
     disabled: boolean;
@@ -48,12 +48,19 @@ const GroupBySelector = ({
     disabled,
 }: GroupBySelectorProps) => {
     return (
-        <div className="mt-2">
+        <div
+            className="mt-2"
+            data-testid={
+                disabled
+                    ? "group-by-select-disabled"
+                    : "group-by-select-enabled"
+            }
+        >
             <div className="text-base leading-5 text-secondary-base mb-1">
                 Group by:
             </div>
             <Select
-                value={disabled ? undefined : groupBy}
+                value={disabled ? "" : groupBy}
                 onValueChange={(value) => setGroupBy(value as GroupByOption)}
                 disabled={disabled}
             >
@@ -68,7 +75,10 @@ const GroupBySelector = ({
                     side="bottom"
                     align="start"
                 >
-                    <SelectGroup className="flex flex-col gap-y-1">
+                    <SelectGroup
+                        className="flex flex-col gap-y-1"
+                        data-testid="group-by-options"
+                    >
                         {groupByOptions.map((option) => (
                             <SelectItem
                                 className="data-highlighted:bg-secondary-lighter data-[state=checked]:bg-secondary-light/70 data-[state=checked]:text-secondary-darkest text-secondary-dark cursor-pointer"

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/GroupBySelector.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/GroupBySelector.tsx
@@ -1,0 +1,89 @@
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/app/components/ui/select";
+import { Dispatch, SetStateAction } from "react";
+
+const groupByValues = [
+    "assetClass",
+    "sector",
+    "country",
+    "noGrouping",
+] as const;
+
+export type GroupByOption = (typeof groupByValues)[number];
+
+const groupByOptions = [
+    {
+        label: "Asset class",
+        value: "assetClass",
+    },
+    {
+        label: "Sector",
+        value: "sector",
+    },
+    {
+        label: "Country",
+        value: "country",
+    },
+    {
+        label: "No grouping",
+        value: "noGrouping",
+    },
+];
+
+interface GroupBySelectorProps {
+    groupBy: GroupByOption;
+    setGroupBy: Dispatch<SetStateAction<GroupByOption>>;
+    disabled: boolean;
+}
+
+const GroupBySelector = ({
+    groupBy,
+    setGroupBy,
+    disabled,
+}: GroupBySelectorProps) => {
+    return (
+        <div className="mt-2">
+            <div className="text-base leading-5 text-secondary-base mb-1">
+                Group by:
+            </div>
+            <Select
+                value={disabled ? undefined : groupBy}
+                onValueChange={(value) => setGroupBy(value as GroupByOption)}
+                disabled={disabled}
+            >
+                <SelectTrigger
+                    className="max-w-36 border-secondary-dark bg-secondary-lighter text-secondary-dark ring-secondary-dark"
+                    iconClassName="text-secondary-dark"
+                >
+                    <SelectValue data-testid="group-by-select-value" />
+                </SelectTrigger>
+                <SelectContent
+                    className="border-secondary-base bg-secondary-lightest text-secondary-dark"
+                    side="bottom"
+                    align="start"
+                >
+                    <SelectGroup className="flex flex-col gap-y-1">
+                        {groupByOptions.map((option) => (
+                            <SelectItem
+                                className="data-highlighted:bg-secondary-lighter data-[state=checked]:bg-secondary-light/70 data-[state=checked]:text-secondary-darkest text-secondary-dark cursor-pointer"
+                                iconClassName="text-secondary-dark"
+                                key={option.value}
+                                value={option.value}
+                            >
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectGroup>
+                </SelectContent>
+            </Select>
+        </div>
+    );
+};
+
+export default GroupBySelector;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/PieChartSkeleton.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/PieChartSkeleton.tsx
@@ -2,14 +2,12 @@ import { Skeleton } from "@/app/components/ui/skeleton";
 
 const PieChartSkeleton = () => {
     return (
-        <div className="flex flex-col gap-y-5 mt-2 items-center">
+        <div
+            className="flex flex-col gap-y-5 mt-2 items-center"
+            data-testid="pie-chart-skeleton"
+        >
             <Skeleton className="h-52 w-52 rounded-full bg-secondary-base/30" />
-            <div className="grid grid-cols-2 grid-rows-3 gap-2 w-full">
-                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
-                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
-                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
-                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
-            </div>
+            <Skeleton className="h-10 w-full rounded-xl bg-secondary-base/30" />
         </div>
     );
 };

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/PieChartSkeleton.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/PieChartSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/app/components/ui/skeleton";
+
+const PieChartSkeleton = () => {
+    return (
+        <div className="flex flex-col gap-y-5 mt-2 items-center">
+            <Skeleton className="h-52 w-52 rounded-full bg-secondary-base/30" />
+            <div className="grid grid-cols-2 grid-rows-3 gap-2 w-full">
+                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
+                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
+                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
+                <Skeleton className="h-5 w-full rounded-xl bg-secondary-base/30" />
+            </div>
+        </div>
+    );
+};
+
+export default PieChartSkeleton;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/placeholderChartData.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/AssetAllocationCard/placeholderChartData.ts
@@ -1,0 +1,34 @@
+import type { ChartDataItem } from "./AssetAllocationChart";
+
+export const placeholderData = [
+    {
+        label: "Sector 1",
+        currentValue: 5,
+        fill: "var(--secondary-light)",
+    },
+    {
+        label: "Sector 2",
+        currentValue: 10,
+        fill: "var(--secondary-light)",
+    },
+    {
+        label: "Sector 3",
+        currentValue: 12,
+        fill: "var(--secondary-light)",
+    },
+    {
+        label: "Sector 4",
+        currentValue: 16,
+        fill: "var(--secondary-light)",
+    },
+    {
+        label: "Sector 5",
+        currentValue: 12,
+        fill: "var(--secondary-light)",
+    },
+    {
+        label: "Sector 6",
+        currentValue: 8,
+        fill: "var(--secondary-light)",
+    },
+] as ChartDataItem[];

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.test.tsx
@@ -4,23 +4,7 @@ import { renderWithContext } from "@/app/tests/utils";
 import { screen } from "@testing-library/react";
 import { TooltipProvider } from "@/app/components/ui/tooltip";
 import MockSessionProvider from "@/app/tests/_mocks/MockSessionProvider";
-
-const mockInvestmentsData = [
-    {
-        assetId: 1,
-        symbol: "LEON",
-        assetCountryId: 224,
-        assetCurrency: "USD",
-        name: "Leonida Inc.",
-        shares: 20,
-        type: "STOCK",
-        currentValue: 2219.2,
-        currentAssetCurrencyValue: 3040,
-        currentReturn: 1489.2,
-        currentReturnPercentage: 204,
-        totalBuyAmount: 730,
-    },
-] satisfies Investment[];
+import { mockInvestmentsData } from "./_mocks/mockInvestmentData";
 
 const mockUseInvestmentsList = vi.fn();
 

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
@@ -11,7 +11,7 @@ import AddTradeModal from "../AddTrade/AddTradeModal";
 export type Investment =
     paths["/portfolios/{portfolioId}/investments"]["get"]["responses"]["200"]["content"]["application/json"]["data"][number];
 
-const noPortfolioSelectedData: Investment[] = Array.from({ length: 5 }, () => ({
+const noPortfolioSelectedData = Array.from({ length: 5 }, () => ({
     assetId: 0,
     symbol: "",
     assetCountryId: 0,
@@ -23,7 +23,6 @@ const noPortfolioSelectedData: Investment[] = Array.from({ length: 5 }, () => ({
     currentReturn: 0,
     currentAssetCurrencyValue: null,
     currentReturnPercentage: 0,
-    totalBuyAmount: 0,
 }));
 
 const NoInvestmentsComponent = () => (
@@ -60,10 +59,14 @@ const InvestmentsTable = ({ portfolioId }: InvestmentsTableProps) => {
                         setIsAddTradeModalOpen,
                         setInvestmentToAddTradeFor,
                     )}
-                    data={isPortfolioSelected ? data : noPortfolioSelectedData}
+                    data={
+                        isPortfolioSelected
+                            ? data
+                            : (noPortfolioSelectedData as Investment[])
+                    }
                     isLoading={isLoading}
                     noResultsComponent={
-                        isPortfolioSelected && <NoInvestmentsComponent />
+                        isPortfolioSelected ? <NoInvestmentsComponent /> : null
                     }
                 />
             </div>

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/InvestmentsTable.tsx
@@ -11,10 +11,6 @@ import AddTradeModal from "../AddTrade/AddTradeModal";
 export type Investment =
     paths["/portfolios/{portfolioId}/investments"]["get"]["responses"]["200"]["content"]["application/json"]["data"][number];
 
-interface InvestmentsTableProps {
-    portfolioId: number | null;
-}
-
 const noPortfolioSelectedData: Investment[] = Array.from({ length: 5 }, () => ({
     assetId: 0,
     symbol: "",
@@ -35,6 +31,10 @@ const NoInvestmentsComponent = () => (
         No investments found for this portfolio.
     </div>
 );
+
+interface InvestmentsTableProps {
+    portfolioId: number | null;
+}
 
 const InvestmentsTable = ({ portfolioId }: InvestmentsTableProps) => {
     const { data, isLoading, refetch } = useInvestmentsList(portfolioId);

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/_mocks/mockInvestmentData.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/_mocks/mockInvestmentData.ts
@@ -1,0 +1,24 @@
+import type { Investment } from "../InvestmentsTable";
+
+export const mockInvestmentsData = [
+    {
+        assetId: 1,
+        symbol: "LEON",
+        assetCountryId: 224,
+        assetCurrency: "USD",
+        name: "Leonida Inc.",
+        shares: 20,
+        type: "STOCK",
+        currentValue: 2219.2,
+        currentAssetCurrencyValue: 3040,
+        currentReturn: 1489.2,
+        currentReturnPercentage: 204,
+        totalBuyAmount: 730,
+        sectorDetails: [
+            {
+                sector: "technology",
+                weight: 1,
+            },
+        ],
+    },
+] satisfies Investment[];

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/investmentsTableColumns.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/InvestmentsTable/investmentsTableColumns.tsx
@@ -106,7 +106,7 @@ export const columns = (
         header: `Return (${userCurrency})`,
         meta: {
             align: "right",
-            headerClassName: "w-[150px]",
+            headerClassName: "w-[175px]",
         },
         cell: ({ row }) => {
             const { currentReturn, currentReturnPercentage } = row.original;
@@ -114,13 +114,14 @@ export const columns = (
             const isPositive = currentReturn > 0;
             const sign = isPositive ? "+" : "";
 
-            const isPlaceholderRow = row.original.currentReturn === 0 && row.original.shares === 0;
+            const isPlaceholderRow =
+                row.original.currentReturn === 0 && row.original.shares === 0;
 
             return isPlaceholderRow ? (
                 "---"
             ) : (
                 <div
-                    className={`flex flex-col justify-end text-sm leading-4 font-sans ${isPositive ? "text-positive-base" : "text-negative-base"}`}
+                    className={`flex flex-col justify-end text-sm leading-4 text-nowrap font-sans ${isPositive ? "text-positive-base" : "text-negative-base"}`}
                 >
                     <span>
                         {sign} {currentReturn.toLocaleString()}
@@ -142,7 +143,10 @@ export const columns = (
         cell: ({ row }) => (
             <div className="flex flex-row gap-2">
                 <Button
-                    disabled={row.original.currentReturn === 0 && row.original.shares === 0}
+                    disabled={
+                        row.original.currentReturn === 0 &&
+                        row.original.shares === 0
+                    }
                     variant="link"
                     className="font-medium text-primary-darker hover:text-primary-dark transition-colors hover:underline hover:cursor-pointer"
                     onClick={() => {

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/PortfolioValueChart/PortfolioValueChart.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/PortfolioValueChart/PortfolioValueChart.tsx
@@ -106,7 +106,7 @@ const PortfolioValueChart = ({ portfolioId }: PortfolioValueChartProps) => {
                         color: "var(--muted-base)",
                     },
                 }}
-                className="aspect-auto w-full h-[250px]"
+                className="aspect-auto h-56"
             >
                 <AreaChart
                     data={

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
@@ -8,6 +8,7 @@ import InvestmentsTable from "./InvestmentsTable/InvestmentsTable";
 import AddInvestmentButton from "./AddInvestment/AddInvestmentButton";
 import PortfolioValueChart from "./PortfolioValueChart/PortfolioValueChart";
 import PortfolioMetrics from "./PortfolioMetrics/PortfolioMetrics";
+import AssetAllocationCard from "./AssetAllocationCard/AssetAllocationCard";
 
 export default function PortfoliosPage() {
     const { data, isLoading } = usePortfolioList();
@@ -50,13 +51,20 @@ export default function PortfoliosPage() {
                 </div>
             </div>
             <div className="mt-8">
-                <div className="flex flex-row items-center justify-between">
-                    <div className="font-sans text-3xl text-primary-base font-semibold">
-                        Investments
+                <div className="flex flex-row gap-x-10 items-center">
+                    <div>
+                        <div className="flex flex-row items-center justify-between">
+                            <div className="font-sans text-3xl text-primary-base font-semibold">
+                                Investments
+                            </div>
+                            <AddInvestmentButton
+                                portfolioId={selectedPortfolioId}
+                            />
+                        </div>
+                        <InvestmentsTable portfolioId={selectedPortfolioId} />
                     </div>
-                    <AddInvestmentButton portfolioId={selectedPortfolioId} />
+                    <AssetAllocationCard portfolioId={selectedPortfolioId} />
                 </div>
-                <InvestmentsTable portfolioId={selectedPortfolioId} />
             </div>
         </div>
     );

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
@@ -28,31 +28,25 @@ export default function PortfoliosPage() {
             <div className="font-sans text-5xl text-primary-base font-semibold">
                 Portfolios
             </div>
-
-            <div className="mt-4 w-full">
-                <div className="flex flex-row">
-                    <div>
-                        <CreatePortfolioButton />
-                        <PortfolioSelector
-                            portfolioList={data}
-                            isLoading={isLoading}
-                            selectedPortfolioId={selectedPortfolioId}
-                            setSelectedPortfolioId={setSelectedPortfolioId}
-                        />
+            <div className="flex flex-row w-full">
+                <div className="flex flex-col w-full">
+                    <div className="flex flex-row mt-4">
+                        <div className="flex flex-col">
+                            <CreatePortfolioButton />
+                            <PortfolioSelector
+                                portfolioList={data}
+                                isLoading={isLoading}
+                                selectedPortfolioId={selectedPortfolioId}
+                                setSelectedPortfolioId={setSelectedPortfolioId}
+                            />
+                        </div>
+                        <div className="ml-4 w-full">
+                            <PortfolioValueChart
+                                portfolioId={selectedPortfolioId}
+                            />
+                        </div>
                     </div>
-                    <div className="ml-4 w-full">
-                        <PortfolioValueChart
-                            portfolioId={selectedPortfolioId}
-                        />
-                    </div>
-                    <div className="ml-13">
-                        <PortfolioMetrics portfolioId={selectedPortfolioId} />
-                    </div>
-                </div>
-            </div>
-            <div className="mt-8">
-                <div className="flex flex-row gap-x-10 items-center">
-                    <div>
+                    <div className="flex flex-col mt-4">
                         <div className="flex flex-row items-center justify-between">
                             <div className="font-sans text-3xl text-primary-base font-semibold">
                                 Investments
@@ -63,6 +57,9 @@ export default function PortfoliosPage() {
                         </div>
                         <InvestmentsTable portfolioId={selectedPortfolioId} />
                     </div>
+                </div>
+                <div className="flex flex-col ml-10 mt-4 gap-y-5">
+                    <PortfolioMetrics portfolioId={selectedPortfolioId} />
                     <AssetAllocationCard portfolioId={selectedPortfolioId} />
                 </div>
             </div>

--- a/apps/ui/stratify-ui/app/components/ui/button.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium font-sans transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium font-sans transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
     {
         variants: {
             variant: {

--- a/apps/ui/stratify-ui/app/components/ui/chart.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/chart.tsx
@@ -1,357 +1,390 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as RechartsPrimitive from "recharts"
+import type {
+    NameType,
+    ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const
+const THEMES = { light: "", dark: ".dark" } as const;
 
-export type ChartConfig = {
-  [k in string]: {
-    label?: React.ReactNode
-    icon?: React.ComponentType
-  } & (
-    | { color?: string; theme?: never }
-    | { color?: never; theme: Record<keyof typeof THEMES, string> }
-  )
+export type ChartConfig = Record<
+    string,
+    {
+        label?: React.ReactNode;
+        icon?: React.ComponentType;
+    } & (
+        | { color?: string; theme?: never }
+        | { color?: never; theme: Record<keyof typeof THEMES, string> }
+    )
+>;
+
+interface ChartContextProps {
+    config: ChartConfig;
 }
 
-type ChartContextProps = {
-  config: ChartConfig
-}
+const ChartContext = React.createContext<ChartContextProps | null>(null);
 
-const ChartContext = React.createContext<ChartContextProps | null>(null)
+export function useChart() {
+    const context = React.useContext(ChartContext);
 
-function useChart() {
-  const context = React.useContext(ChartContext)
+    if (!context) {
+        throw new Error("useChart must be used within a <ChartContainer />");
+    }
 
-  if (!context) {
-    throw new Error("useChart must be used within a <ChartContainer />")
-  }
-
-  return context
+    return context;
 }
 
 function ChartContainer({
-  id,
-  className,
-  children,
-  config,
-  ...props
+    id,
+    className,
+    children,
+    config,
+    ...props
 }: React.ComponentProps<"div"> & {
-  config: ChartConfig
-  children: React.ComponentProps<
-    typeof RechartsPrimitive.ResponsiveContainer
-  >["children"]
+    config: ChartConfig;
+    children: React.ComponentProps<
+        typeof RechartsPrimitive.ResponsiveContainer
+    >["children"];
 }) {
-  const uniqueId = React.useId()
-  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+    const uniqueId = React.useId();
+    const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`;
 
-  return (
-    <ChartContext.Provider value={{ config }}>
-      <div
-        data-slot="chart"
-        data-chart={chartId}
-        className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
-          className
-        )}
-        {...props}
-      >
-        <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>
-          {children}
-        </RechartsPrimitive.ResponsiveContainer>
-      </div>
-    </ChartContext.Provider>
-  )
+    return (
+        <ChartContext.Provider value={{ config }}>
+            <div
+                data-slot="chart"
+                data-chart={chartId}
+                className={cn(
+                    "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+                    className,
+                )}
+                {...props}
+            >
+                <ChartStyle id={chartId} config={config} />
+                <RechartsPrimitive.ResponsiveContainer>
+                    {children}
+                </RechartsPrimitive.ResponsiveContainer>
+            </div>
+        </ChartContext.Provider>
+    );
 }
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([, config]) => config.theme || config.color
-  )
+    const colorConfig = Object.entries(config).filter(
+        ([, config]) => config.theme ?? config.color,
+    );
 
-  if (!colorConfig.length) {
-    return null
-  }
+    if (!colorConfig.length) {
+        return null;
+    }
 
-  return (
-    <style
-      dangerouslySetInnerHTML={{
-        __html: Object.entries(THEMES)
-          .map(
-            ([theme, prefix]) => `
+    return (
+        <style
+            dangerouslySetInnerHTML={{
+                __html: Object.entries(THEMES)
+                    .map(
+                        ([theme, prefix]) => `
 ${prefix} [data-chart=${id}] {
 ${colorConfig
-  .map(([key, itemConfig]) => {
-    const color =
-      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-      itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
-  })
-  .join("\n")}
+    .map(([key, itemConfig]) => {
+        const color =
+            itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
+            itemConfig.color;
+        return color ? `  --color-${key}: ${color};` : null;
+    })
+    .join("\n")}
 }
-`
-          )
-          .join("\n"),
-      }}
-    />
-  )
-}
+`,
+                    )
+                    .join("\n"),
+            }}
+        />
+    );
+};
 
-const ChartTooltip = RechartsPrimitive.Tooltip
+const ChartTooltip = RechartsPrimitive.Tooltip;
 
 function ChartTooltipContent({
-  active,
-  payload,
-  className,
-  indicator = "dot",
-  hideLabel = false,
-  hideIndicator = false,
-  label,
-  labelFormatter,
-  labelClassName,
-  formatter,
-  color,
-  nameKey,
-  labelKey,
-}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-  React.ComponentProps<"div"> & {
-    hideLabel?: boolean
-    hideIndicator?: boolean
-    indicator?: "line" | "dot" | "dashed"
-    nameKey?: string
-    labelKey?: string
-  }) {
-  const { config } = useChart()
-
-  const tooltipLabel = React.useMemo(() => {
-    if (hideLabel || !payload?.length) {
-      return null
-    }
-
-    const [item] = payload
-    const key = `${labelKey || item?.dataKey || item?.name || "value"}`
-    const itemConfig = getPayloadConfigFromPayload(config, item, key)
-    const value =
-      !labelKey && typeof label === "string"
-        ? config[label as keyof typeof config]?.label || label
-        : itemConfig?.label
-
-    if (labelFormatter) {
-      return (
-        <div className={cn("font-medium", labelClassName)}>
-          {labelFormatter(value, payload)}
-        </div>
-      )
-    }
-
-    if (!value) {
-      return null
-    }
-
-    return <div className={cn("font-medium", labelClassName)}>{value}</div>
-  }, [
-    label,
+    active,
+    className,
+    indicator = "dot",
+    hideLabel = false,
+    hideIndicator = false,
     labelFormatter,
-    payload,
-    hideLabel,
     labelClassName,
-    config,
+    formatter,
+    color,
+    nameKey,
     labelKey,
-  ])
+    payload,
+    label,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+        hideLabel?: boolean;
+        hideIndicator?: boolean;
+        indicator?: "line" | "dot" | "dashed";
+        nameKey?: string;
+        labelKey?: string;
+    } & Omit<
+        RechartsPrimitive.DefaultTooltipContentProps<ValueType, NameType>,
+        "accessibilityLayer"
+    >) {
+    const { config } = useChart();
 
-  if (!active || !payload?.length) {
-    return null
-  }
+    const tooltipLabel = React.useMemo(() => {
+        if (hideLabel || !payload?.length) {
+            return null;
+        }
 
-  const nestLabel = payload.length === 1 && indicator !== "dot"
+        const [item] = payload;
+        const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+        const value =
+            !labelKey && typeof label === "string"
+                ? (config[label]?.label ?? label)
+                : itemConfig?.label;
 
-  return (
-    <div
-      className={cn(
-        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
-        className
-      )}
-    >
-      {!nestLabel ? tooltipLabel : null}
-      <div className="grid gap-1.5">
-        {payload
-          .filter((item) => item.type !== "none")
-          .map((item, index) => {
-            const key = `${nameKey || item.name || item.dataKey || "value"}`
-            const itemConfig = getPayloadConfigFromPayload(config, item, key)
-            const indicatorColor = color || item.payload.fill || item.color
-
+        if (labelFormatter) {
             return (
-              <div
-                key={item.dataKey}
-                className={cn(
-                  "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
-                  indicator === "dot" && "items-center"
-                )}
-              >
-                {formatter && item?.value !== undefined && item.name ? (
-                  formatter(item.value, item.name, item, index, item.payload)
-                ) : (
-                  <>
-                    {itemConfig?.icon ? (
-                      <itemConfig.icon />
-                    ) : (
-                      !hideIndicator && (
+                <div className={cn("font-medium", labelClassName)}>
+                    {labelFormatter(value, payload)}
+                </div>
+            );
+        }
+
+        if (!value) {
+            return null;
+        }
+
+        return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+    }, [
+        config,
+        hideLabel,
+        label,
+        labelClassName,
+        labelFormatter,
+        labelKey,
+        payload,
+    ]);
+
+    if (!active || !payload?.length) {
+        return null;
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot";
+
+    return (
+        <div
+            className={cn(
+                "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+                className,
+            )}
+        >
+            {!nestLabel ? tooltipLabel : null}
+            <div className="grid gap-1.5">
+                {payload.map((item, index) => {
+                    const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
+                    const itemConfig = getPayloadConfigFromPayload(
+                        config,
+                        item,
+                        key,
+                    );
+                    const indicatorColor =
+                        color ?? item.payload?.fill ?? item.color;
+
+                    return (
                         <div
-                          className={cn(
-                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
-                            {
-                              "h-2.5 w-2.5": indicator === "dot",
-                              "w-1": indicator === "line",
-                              "w-0 border-[1.5px] border-dashed bg-transparent":
-                                indicator === "dashed",
-                              "my-0.5": nestLabel && indicator === "dashed",
-                            }
-                          )}
-                          style={
-                            {
-                              "--color-bg": indicatorColor,
-                              "--color-border": indicatorColor,
-                            } as React.CSSProperties
-                          }
-                        />
-                      )
-                    )}
-                    <div
-                      className={cn(
-                        "flex flex-1 justify-between leading-none",
-                        nestLabel ? "items-end" : "items-center"
-                      )}
-                    >
-                      <div className="grid gap-1.5">
-                        {nestLabel ? tooltipLabel : null}
-                        <span className="text-muted-foreground">
-                          {itemConfig?.label || item.name}
-                        </span>
-                      </div>
-                      {item.value && (
-                        <span className="text-foreground font-mono font-medium tabular-nums">
-                          {item.value.toLocaleString()}
-                        </span>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
-            )
-          })}
-      </div>
-    </div>
-  )
+                            key={index}
+                            className={cn(
+                                "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                                indicator === "dot" && "items-center",
+                            )}
+                        >
+                            {formatter &&
+                            item?.value !== undefined &&
+                            item.name ? (
+                                formatter(
+                                    item.value,
+                                    item.name,
+                                    item,
+                                    index,
+                                    item.payload,
+                                )
+                            ) : (
+                                <>
+                                    {itemConfig?.icon ? (
+                                        <itemConfig.icon />
+                                    ) : (
+                                        !hideIndicator && (
+                                            <div
+                                                className={cn(
+                                                    "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                                                    {
+                                                        "h-2.5 w-2.5":
+                                                            indicator === "dot",
+                                                        "w-1":
+                                                            indicator ===
+                                                            "line",
+                                                        "w-0 border-[1.5px] border-dashed bg-transparent":
+                                                            indicator ===
+                                                            "dashed",
+                                                        "my-0.5":
+                                                            nestLabel &&
+                                                            indicator ===
+                                                                "dashed",
+                                                    },
+                                                )}
+                                                style={
+                                                    {
+                                                        "--color-bg":
+                                                            indicatorColor,
+                                                        "--color-border":
+                                                            indicatorColor,
+                                                    } as React.CSSProperties
+                                                }
+                                            />
+                                        )
+                                    )}
+                                    <div
+                                        className={cn(
+                                            "flex flex-1 justify-between leading-none",
+                                            nestLabel
+                                                ? "items-end"
+                                                : "items-center",
+                                        )}
+                                    >
+                                        <div className="grid gap-1.5">
+                                            {nestLabel ? tooltipLabel : null}
+                                            <span className="text-muted-foreground">
+                                                {itemConfig?.label ?? item.name}
+                                            </span>
+                                        </div>
+                                        {item.value != null && (
+                                            <span className="font-mono font-medium text-foreground tabular-nums">
+                                                {typeof item.value === "number"
+                                                    ? item.value.toLocaleString()
+                                                    : String(item.value)}
+                                            </span>
+                                        )}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
 }
 
-const ChartLegend = RechartsPrimitive.Legend
+const ChartLegend = RechartsPrimitive.Legend;
 
 function ChartLegendContent({
-  className,
-  hideIcon = false,
-  payload,
-  verticalAlign = "bottom",
-  nameKey,
-}: React.ComponentProps<"div"> &
-  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-    hideIcon?: boolean
-    nameKey?: string
-  }) {
-  const { config } = useChart()
+    className,
+    hideIcon = false,
+    nameKey,
+    payload,
+    verticalAlign,
+}: React.ComponentProps<"div"> & {
+    hideIcon?: boolean;
+    nameKey?: string;
+} & RechartsPrimitive.DefaultLegendContentProps) {
+    const { config } = useChart();
 
-  if (!payload?.length) {
-    return null
-  }
+    if (!payload?.length) {
+        return null;
+    }
 
-  return (
-    <div
-      className={cn(
-        "flex items-center justify-center gap-4",
-        verticalAlign === "top" ? "pb-3" : "pt-3",
-        className
-      )}
-    >
-      {payload
-        .filter((item) => item.type !== "none")
-        .map((item) => {
-          const key = `${nameKey || item.dataKey || "value"}`
-          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const topSixSectors = payload.slice(0, 6);
 
-          return (
-            <div
-              key={item.value}
-              className={cn(
-                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
-              )}
-            >
-              {itemConfig?.icon && !hideIcon ? (
-                <itemConfig.icon />
-              ) : (
-                <div
-                  className="h-2 w-2 shrink-0 rounded-[2px]"
-                  style={{
-                    backgroundColor: item.color,
-                  }}
-                />
-              )}
-              {itemConfig?.label}
-            </div>
-          )
-        })}
-    </div>
-  )
+    return (
+        <div
+            className={cn(
+                "grid grid-cols-2 items-center justify-center gap-4 font-sans text-secondary-dark max-h-32",
+                verticalAlign === "top" ? "pb-3" : "pt-3",
+                className,
+            )}
+        >
+            {topSixSectors.map((item) => {
+                const key = `${nameKey ?? item.dataKey ?? "value"}`;
+                const itemConfig = getPayloadConfigFromPayload(
+                    config,
+                    item,
+                    key,
+                );
+
+                return (
+                    <div
+                        key={item.value}
+                        className={cn(
+                            "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-dark",
+                        )}
+                    >
+                        {itemConfig?.icon && !hideIcon ? (
+                            <itemConfig.icon />
+                        ) : (
+                            <div
+                                className="h-2 w-2 shrink-0 rounded-full"
+                                style={{
+                                    backgroundColor: item.color,
+                                }}
+                            />
+                        )}
+                        {itemConfig?.label}
+                    </div>
+                );
+            })}
+        </div>
+    );
 }
 
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(
-  config: ChartConfig,
-  payload: unknown,
-  key: string
+    config: ChartConfig,
+    payload: unknown,
+    key: string,
 ) {
-  if (typeof payload !== "object" || payload === null) {
-    return undefined
-  }
+    if (typeof payload !== "object" || payload === null) {
+        return undefined;
+    }
 
-  const payloadPayload =
-    "payload" in payload &&
-    typeof payload.payload === "object" &&
-    payload.payload !== null
-      ? payload.payload
-      : undefined
+    const payloadPayload =
+        "payload" in payload &&
+        typeof payload.payload === "object" &&
+        payload.payload !== null
+            ? payload.payload
+            : undefined;
 
-  let configLabelKey: string = key
+    let configLabelKey: string = key;
 
-  if (
-    key in payload &&
-    typeof payload[key as keyof typeof payload] === "string"
-  ) {
-    configLabelKey = payload[key as keyof typeof payload] as string
-  } else if (
-    payloadPayload &&
-    key in payloadPayload &&
-    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
-  ) {
-    configLabelKey = payloadPayload[
-      key as keyof typeof payloadPayload
-    ] as string
-  }
+    if (
+        key in payload &&
+        typeof payload[key as keyof typeof payload] === "string"
+    ) {
+        configLabelKey = payload[key as keyof typeof payload] as string;
+    } else if (
+        payloadPayload &&
+        key in payloadPayload &&
+        typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+    ) {
+        configLabelKey = payloadPayload[
+            key as keyof typeof payloadPayload
+        ] as string;
+    }
 
-  return configLabelKey in config
-    ? config[configLabelKey]
-    : config[key as keyof typeof config]
+    return configLabelKey in config ? config[configLabelKey] : config[key];
 }
 
 export {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  ChartLegend,
-  ChartLegendContent,
-  ChartStyle,
-}
+    ChartContainer,
+    ChartTooltip,
+    ChartTooltipContent,
+    ChartLegend,
+    ChartLegendContent,
+    ChartStyle,
+};

--- a/apps/ui/stratify-ui/app/components/ui/data-table.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/data-table.tsx
@@ -105,7 +105,7 @@ export function DataTable<TData, TValue>({
                                         <TableHead
                                             key={header.id}
                                             className={cn(
-                                                "text-left", //? Default alignment
+                                                "text-left xl:text-nowrap",
                                                 shouldAlignRight &&
                                                     "text-right",
                                                 align === "center" &&
@@ -268,7 +268,10 @@ export function DataTable<TData, TValue>({
                     </div>
                     <div className="flex flex-row items-center">
                         <PaginationPrevious
-                            onClick={() => table.previousPage()}
+                            onClick={() =>
+                                table.getCanPreviousPage() &&
+                                table.previousPage()
+                            }
                             className={cn(
                                 !table.getCanPreviousPage() &&
                                     "opacity-50 cursor-default",
@@ -294,7 +297,9 @@ export function DataTable<TData, TValue>({
                             )}
                         </PaginationContent>
                         <PaginationNext
-                            onClick={() => table.nextPage()}
+                            onClick={() =>
+                                table.getCanNextPage() && table.nextPage()
+                            }
                             className={cn(
                                 !table.getCanNextPage() &&
                                     "opacity-50 cursor-default",

--- a/apps/ui/stratify-ui/app/components/ui/select.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/select.tsx
@@ -12,10 +12,16 @@ const SelectGroup = SelectPrimitive.Group;
 
 const SelectValue = SelectPrimitive.Value;
 
+interface SelectTriggerProps extends React.ComponentPropsWithoutRef<
+    typeof SelectPrimitive.Trigger
+> {
+    iconClassName?: string;
+}
+
 const SelectTrigger = React.forwardRef<
     React.ElementRef<typeof SelectPrimitive.Trigger>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+    SelectTriggerProps
+>(({ className, children, iconClassName, ...props }, ref) => (
     <SelectPrimitive.Trigger
         ref={ref}
         className={cn(
@@ -26,7 +32,9 @@ const SelectTrigger = React.forwardRef<
     >
         {children}
         <SelectPrimitive.Icon asChild>
-            <ChevronDown className="h-4 w-4 text-primary-dark" />
+            <ChevronDown
+                className={cn("h-4 w-4 text-primary-dark", iconClassName)}
+            />
         </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
 ));
@@ -111,10 +119,16 @@ const SelectLabel = React.forwardRef<
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
+interface SelectItemProps extends React.ComponentPropsWithoutRef<
+    typeof SelectPrimitive.Item
+> {
+    iconClassName?: string;
+}
+
 const SelectItem = React.forwardRef<
     React.ElementRef<typeof SelectPrimitive.Item>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+    SelectItemProps
+>(({ className, iconClassName, children, ...props }, ref) => (
     <SelectPrimitive.Item
         ref={ref}
         className={cn(
@@ -125,7 +139,9 @@ const SelectItem = React.forwardRef<
     >
         <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
             <SelectPrimitive.ItemIndicator>
-                <Check className="h-4 w-4 text-primary-dark" />
+                <Check
+                    className={cn("h-4 w-4 text-primary-dark", iconClassName)}
+                />
             </SelectPrimitive.ItemIndicator>
         </span>
         <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>

--- a/apps/ui/stratify-ui/app/components/ui/tooltip.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/tooltip.tsx
@@ -30,12 +30,19 @@ function TooltipTrigger({
     return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
+interface TooltipContentProps extends React.ComponentProps<
+    typeof TooltipPrimitive.Content
+> {
+    arrowClassName?: string;
+}
+
 function TooltipContent({
     className,
     sideOffset = 0,
     children,
+    arrowClassName,
     ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: TooltipContentProps) {
     return (
         <TooltipPrimitive.Portal>
             <TooltipPrimitive.Content
@@ -48,7 +55,12 @@ function TooltipContent({
                 {...props}
             >
                 {children}
-                <TooltipPrimitive.Arrow className="bg-primary-base fill-primary-base z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+                <TooltipPrimitive.Arrow
+                    className={cn(
+                        "bg-primary-base fill-primary-base z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]",
+                        arrowClassName,
+                    )}
+                />
             </TooltipPrimitive.Content>
         </TooltipPrimitive.Portal>
     );

--- a/apps/ui/stratify-ui/package.json
+++ b/apps/ui/stratify-ui/package.json
@@ -47,7 +47,7 @@
         "react-day-picker": "^9.13.2",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.69.0",
-        "recharts": "2.15.4",
+        "recharts": "3.8.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: ^7.69.0
         version: 7.69.0(react@19.1.0)
       recharts:
-        specifier: 2.15.4
-        version: 2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 3.8.0
+        version: 3.8.0(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2131,6 +2131,17 @@ packages:
     resolution: {integrity: sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -2725,6 +2736,9 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.50.1':
     resolution: {integrity: sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==}
@@ -3633,9 +3647,6 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dom-helpers@5.2.1:
-    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
-
   dotenv-cli@11.0.0:
     resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
     hasBin: true
@@ -3724,6 +3735,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -3932,8 +3946,8 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
-  eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -3964,10 +3978,6 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-
-  fast-equals@5.4.0:
-    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
-    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -4286,6 +4296,12 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -5315,6 +5331,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -5339,12 +5367,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-smooth@4.0.4:
-    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -5354,12 +5376,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react-transition-group@4.4.5:
-    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
-    peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -5385,15 +5401,13 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
-  recharts-scale@0.4.5:
-    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
-
-  recharts@2.15.4:
-    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
-    engines: {node: '>=14'}
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
@@ -5402,6 +5416,14 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -6000,8 +6022,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  victory-vendor@36.9.2:
-    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -8275,6 +8297,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.1.0
+      react-redux: 9.2.0(@types/react@19.2.7)(react@19.1.0)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
@@ -8899,6 +8933,8 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -9880,11 +9916,6 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dom-helpers@5.2.1:
-    dependencies:
-      '@babel/runtime': 7.28.4
-      csstype: 3.2.3
-
   dotenv-cli@11.0.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -10040,6 +10071,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -10392,7 +10425,7 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
-  eventemitter3@4.0.7: {}
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -10412,8 +10445,6 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
-
-  fast-equals@5.4.0: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -10774,6 +10805,10 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -11843,6 +11878,15 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-redux@9.2.0(@types/react@19.2.7)(react@19.1.0)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.1.0
+      use-sync-external-store: 1.6.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      redux: 5.0.1
+
   react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.1.0):
@@ -11864,14 +11908,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  react-smooth@4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      fast-equals: 5.4.0
-      prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-transition-group: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-
   react-style-singleton@2.2.3(@types/react@19.2.7)(react@19.1.0):
     dependencies:
       get-nonce: 1.0.1
@@ -11879,15 +11915,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.28.4
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
 
@@ -11917,22 +11944,25 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts-scale@0.4.5:
+  recharts@3.8.0(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(redux@5.0.1):
     dependencies:
-      decimal.js-light: 2.5.1
-
-  recharts@2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       clsx: 2.1.1
-      eventemitter3: 4.0.7
-      lodash: 4.17.21
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-is: 18.3.1
-      react-smooth: 4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      recharts-scale: 0.4.5
+      react-redux: 9.2.0(@types/react@19.2.7)(react@19.1.0)(redux@5.0.1)
+      reselect: 5.1.1
       tiny-invariant: 1.3.3
-      victory-vendor: 36.9.2
+      use-sync-external-store: 1.6.0(react@19.1.0)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
 
   rechoir@0.6.2:
     dependencies:
@@ -11942,6 +11972,12 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -12619,7 +12655,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  victory-vendor@36.9.2:
+  victory-vendor@37.3.6:
     dependencies:
       '@types/d3-array': 3.2.2
       '@types/d3-ease': 3.0.2


### PR DESCRIPTION
## Stratify UI
- Build component for displaying the asset allocation for a portfolio within a pie chart
- Allow for grouping assets by asset class, sector or country in the pie chart
- Display a tooltip when hovering over a sector in the pie chart to display information relevant to that sector based on the grouping
- Display a legend in place of the pie chart through a toggle to show which colours correspond to which sectors in the pie chart
- Add unit tests for the asset allocation component
- Change the layout of the portfolio page to display the asset allocation component in line with the overall return and overall risk cards
## Stratify API
- Change function for retrieving investments to also retrieve the sector for each asset (or sectors and the weights for those sectors if it is a fund)
- Organise functions and endpoint files related to individual portfolios into separate folders
## Stratify Data API
- Change fund endpoints to retrieve the sector weights for the assets held in each fund 
- Add mappings to ensure that the sector names are consistent between funds and stocks