### PR TITLE
AB#313 - Build learn page and add learn cards

### DIFF
--- a/.changeset/plenty-clubs-turn.md
+++ b/.changeset/plenty-clubs-turn.md
@@ -1,0 +1,9 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+- Build Learn page
+- Build Learn Card to display a title and short description of a learning guide and a clickable button to navigate to the guide
+- Display Learn cards on the Learn page
+- Add unit tests for Learn Card and learn page
+- Add unit tests for asset name card component displayed when searching for an asset to add to a portfolio

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/components/LearnCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/components/LearnCard.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/app/components/ui/button";
+import { useRouter } from "next/navigation";
+
+interface LearnCardProps {
+    title: string;
+    description: string;
+    isComingSoon?: boolean;
+    linkToPage?: string;
+}
+
+const LearnCard = ({
+    title,
+    description,
+    linkToPage = "",
+    isComingSoon = false,
+}: LearnCardProps) => {
+    const { push } = useRouter();
+    return (
+        <div className="flex flex-col gap-y-3 bg-primary-lightest font-sans rounded-xl border border-primary-light px-3 py-2.5">
+            <div className="font-medium text-2xl leading-6 text-secondary-dark">
+                {title}
+            </div>
+            <div className="text-secondary-base text-xl">{description}</div>
+            <Button
+                variant="secondary"
+                disabled={isComingSoon}
+                size="sm"
+                className="self-start"
+                onClick={() => push(linkToPage)}
+                data-testid={
+                    isComingSoon
+                        ? "learn-card-button-disabled"
+                        : "learn-card-button"
+                }
+            >
+                {isComingSoon ? "Coming Soon" : "Open"}
+            </Button>
+        </div>
+    );
+};
+
+export default LearnCard;

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/page.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/page.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LearnPage from "./page";
+import userEvent from "@testing-library/user-event";
+
+const mockNextPush = vi.fn();
+
+const mockUseRouter = {
+    push: mockNextPush,
+};
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => mockUseRouter,
+}));
+
+const user = userEvent.setup();
+
+describe("LearnPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const renderPage = () => render(<LearnPage />);
+
+    it("should render the learn page successfully", () => {
+        renderPage();
+
+        expect(screen.getByText("Learn")).toBeInTheDocument();
+
+        const learnCardTitles = [
+            "Compounding",
+            "Cost Averaging",
+            "Diversification",
+            "Trading Simulator",
+        ];
+
+        learnCardTitles.forEach((title) =>
+            expect(screen.getByText(title)).toBeInTheDocument(),
+        );
+    });
+
+    it("should navigate to the correct page when opening a learn card", async () => {
+        renderPage();
+
+        const compoundingCard = screen.getByText("Compounding");
+        const compoundingButton = within(
+            compoundingCard.parentElement!,
+        ).getByTestId("learn-card-button");
+
+        await user.click(compoundingButton);
+
+        expect(mockNextPush).toHaveBeenCalledWith("/app/learn/compounding");
+    });
+
+    it("should not navigate to a page when attempting to open a coming soon card", async () => {
+        renderPage();
+
+        const diversificationCard = screen.getByText("Diversification");
+        const diversificationButton = within(
+            diversificationCard.parentElement!,
+        ).getByTestId("learn-card-button-disabled");
+
+        await user.click(diversificationButton);
+
+        expect(mockNextPush).not.toHaveBeenCalled();
+    });
+});

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import LearnCard from "./components/LearnCard";
+
+export default function LearnPage() {
+    return (
+        <div className="items-center justify-items-center min-h-screen px-10">
+            <div className="font-sans text-5xl text-primary-base font-semibold leading-14">
+                Learn
+            </div>
+
+            <div className="grid grid-cols-2 gap-x-10 gap-y-5 mt-4 w-full">
+                <LearnCard
+                    title="Compounding"
+                    description="Understand how returns grow on top of returns and the power of keeping money invested for longer."
+                    linkToPage="/app/learn/compounding"
+                />
+                <LearnCard
+                    title="Cost Averaging"
+                    description="Learn how investing a fixed amount of money helps build your portfolio while taking out the emotion."
+                    linkToPage="/app/learn/cost-averaging"
+                />
+                <LearnCard
+                    title="Diversification"
+                    description="Learn why putting your eggs in many baskets supports and protects your portfolio. "
+                    isComingSoon
+                />
+                <LearnCard
+                    title="Trading Simulator"
+                    description="Learn how to trade by doing, get instant feedback and build the confidence to invest for real."
+                    isComingSoon
+                />
+            </div>
+        </div>
+    );
+}

--- a/apps/ui/stratify-ui/app/(screens)/app/markets/AssetSearch/AssetSearch.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/markets/AssetSearch/AssetSearch.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import AssetSearch from "./AssetSearch";
 import { screen } from "@testing-library/react";
 import type { AssetSearchItemProps } from "./AssetSearchItem";
-import { SearchAsset } from "./useAssetSearch";
+import { mockSearchAsset } from "./_mocks/mockAssetSearch";
 
 const user = userEvent.setup();
 
@@ -25,18 +25,7 @@ const mockSearchStatus = vi.fn();
 const mockIsNoResultsFound = vi.fn();
 
 const mockUseAssetSearch = () => ({
-    searchResults: [
-        {
-            id: 1,
-            name: "Apple Inc.",
-            symbol: "AAPL",
-            assetType: "STOCK",
-            currentPrice: 150.25,
-            priceChangePercent: 1.5,
-            priceChange: 2.25,
-            currency: "USD",
-        },
-    ] satisfies SearchAsset[],
+    searchResults: [mockSearchAsset],
     isSearching: mockIsSearching(),
     search: mockSearch,
     resetSearch: mockResetSearch,

--- a/apps/ui/stratify-ui/app/(screens)/app/markets/AssetSearch/_mocks/mockAssetSearch.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/markets/AssetSearch/_mocks/mockAssetSearch.ts
@@ -1,0 +1,12 @@
+import { SearchAsset } from "../useAssetSearch";
+
+export const mockSearchAsset = {
+    id: 1,
+    name: "Apple Inc.",
+    symbol: "AAPL",
+    assetType: "STOCK",
+    currentPrice: 150.25,
+    priceChangePercent: 1.5,
+    priceChange: 2.25,
+    currency: "USD",
+} satisfies SearchAsset;

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AssetNameCard.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AssetNameCard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AssetNameCard from "./AssetNameCard";
+import { mockSearchAsset } from "../../../markets/AssetSearch/_mocks/mockAssetSearch";
+
+const mockOnSelect = vi.fn();
+
+describe("AssetNameCard", () => {
+    const renderComponent = () =>
+        render(
+            <AssetNameCard asset={mockSearchAsset} onSelect={mockOnSelect} />,
+        );
+
+    it("renders asset name card successfully", () => {
+        renderComponent();
+
+        expect(
+            screen.getByText(
+                `${mockSearchAsset.name} (${mockSearchAsset.symbol})`,
+            ),
+        ).toBeInTheDocument();
+
+        expect(screen.getByText("Stock")).toBeInTheDocument();
+    });
+
+    it("should call onSelect when the card is clicked", () => {
+        renderComponent();
+
+        const card = screen.getByTestId("asset-name-card");
+        card.click();
+
+        expect(mockOnSelect).toHaveBeenCalled();
+    });
+});

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AssetNameCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AssetNameCard.tsx
@@ -13,6 +13,7 @@ const AssetNameCard = ({ asset, onSelect }: AssetNameCardProps) => {
         <div
             className="w-full flex flex-row justify-between items-center py-1.5 px-2 font-sans transition-colors rounded-md hover:bg-secondary-lighter text-secondary-darker hover:cursor-pointer"
             onClick={() => onSelect()}
+            data-testid="asset-name-card"
         >
             {asset.name} ({asset.symbol})
             <AssetBadge {...assetTypeMap[asset.assetType]} />


### PR DESCRIPTION
- Build Learn page
- Build Learn Card to display a title and short description of a learning guide and a clickable button to navigate to the guide
- Display Learn cards on the Learn page
- Add unit tests for Learn Card and learn page
- Add unit tests for asset name card component displayed when searching for an asset to add to a portfolio