### PR TITLE
Set selected portfolio to the newly created portfolio automatically

### DIFF
--- a/.changeset/cool-toes-cough.md
+++ b/.changeset/cool-toes-cough.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-api": patch
+---
+
+Return ID of newly created portfolio instead of a success boolean flag

--- a/.changeset/true-groups-sin.md
+++ b/.changeset/true-groups-sin.md
@@ -1,0 +1,6 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+- Fix bug where selected portfolio id is overridden when navigating to the portfolios page from the top performers table for the first time
+- Change functionality on successfully creating a portfolio to set the selected portfolio id to the newly created portfolio

--- a/apps/api/stratify-api/src/routes/portfolios/create.post.test.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/create.post.test.ts
@@ -40,7 +40,7 @@ describe("POST /portfolios", () => {
 
         expect(json).toEqual({
             data: {
-                success: true,
+                portfolioId: expect.any(Number),
             },
         });
     });
@@ -96,7 +96,7 @@ describe("POST /portfolios", () => {
 
         expect(firstPortfolioJson).toEqual({
             data: {
-                success: true,
+                portfolioId: expect.any(Number),
             },
         });
 
@@ -115,7 +115,7 @@ describe("POST /portfolios", () => {
         expect(secondPortfolioResponse.statusCode).toBe(201);
         expect(secondPortfolioJson).toEqual({
             data: {
-                success: true,
+                portfolioId: expect.any(Number),
             },
         });
     });
@@ -139,7 +139,7 @@ describe("POST /portfolios", () => {
 
         expect(firstPortfolioJson).toEqual({
             data: {
-                success: true,
+                portfolioId: expect.any(Number),
             },
         });
 
@@ -181,7 +181,7 @@ describe("POST /portfolios", () => {
 
         expect(firstPortfolioJson).toEqual({
             data: {
-                success: true,
+                portfolioId: expect.any(Number),
             },
         });
 
@@ -200,7 +200,7 @@ describe("POST /portfolios", () => {
         expect(secondPortfolioResponse.statusCode).toBe(201);
         expect(secondPortfolioJson).toEqual({
             data: {
-                success: true,
+                portfolioId: expect.any(Number),
             },
         });
     });

--- a/apps/api/stratify-api/src/routes/portfolios/create.post.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/create.post.ts
@@ -22,7 +22,7 @@ type PortfolioNameAlreadyExistsResponse = Static<
 
 const successResponseSchema = Type.Object({
     data: Type.Object({
-        success: Type.Boolean(),
+        portfolioId: Type.Number(),
     }),
 });
 
@@ -30,10 +30,13 @@ type SuccessResponse = Static<typeof successResponseSchema>;
 
 // Create a new portfolio for the user
 const createPortfolio = (userId: string, name: string) => {
-    return db.insertInto("stratify.portfolios").values({
-        name: name.toLowerCase(),
-        userId,
-    });
+    return db
+        .insertInto("stratify.portfolios")
+        .values({
+            name: name.toLowerCase(),
+            userId,
+        })
+        .returning("id as portfolioId");
 };
 
 // Check if the user already has a portfolio with the same name
@@ -77,11 +80,14 @@ export default async function portfolioCreatePost(fastify: FastifyInstance) {
                     });
                 }
 
-                await createPortfolio(userId, name).execute();
+                const { portfolioId } = await createPortfolio(
+                    userId,
+                    name,
+                ).executeTakeFirstOrThrow();
 
                 return reply.status(201).send({
                     data: {
-                        success: true,
+                        portfolioId,
                     },
                 });
             } catch (error) {

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/CreatePortfolio/CreatePortfolioModal.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/CreatePortfolio/CreatePortfolioModal.test.tsx
@@ -7,6 +7,13 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mockHandleClose = vi.fn();
+const mockSetSelectedPortfolioId = vi.fn();
+
+const defaultProps = {
+    isOpen: true,
+    handleClose: mockHandleClose,
+    setSelectedPortfolioId: mockSetSelectedPortfolioId,
+} satisfies CreatePortfolioModalProps;
 
 const user = userEvent.setup();
 
@@ -19,18 +26,13 @@ describe("CreatePortfolioModal", () => {
         vi.clearAllMocks();
     });
 
-    const renderModal = ({ isOpen, handleClose }: CreatePortfolioModalProps) =>
+    const renderModal = (props?: Partial<CreatePortfolioModalProps>) =>
         renderWithContext({
-            children: (
-                <CreatePortfolioModal
-                    isOpen={isOpen}
-                    handleClose={handleClose}
-                />
-            ),
+            children: <CreatePortfolioModal {...defaultProps} {...props} />,
         });
 
     it("Should render the modal when isOpen is true", () => {
-        renderModal({ isOpen: true, handleClose: mockHandleClose });
+        renderModal();
 
         expect(screen.getByText("Create Portfolio")).toBeInTheDocument();
         expect(
@@ -46,13 +48,13 @@ describe("CreatePortfolioModal", () => {
     });
 
     it("Should not render the modal when isOpen is false", () => {
-        renderModal({ isOpen: false, handleClose: mockHandleClose });
+        renderModal({ isOpen: false });
 
         expect(screen.queryByText("Create Portfolio")).not.toBeInTheDocument();
     });
 
     it("Should call handleClose when the close icon is clicked", async () => {
-        renderModal({ isOpen: true, handleClose: mockHandleClose });
+        renderModal();
 
         const closeIcon = screen.getByTestId("close-modal-icon");
         await user.click(closeIcon);

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/CreatePortfolio/CreatePortfolioModal.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/CreatePortfolio/CreatePortfolioModal.tsx
@@ -10,7 +10,7 @@ import {
     DialogTitle,
 } from "@/app/components/ui/dialog";
 import { X } from "lucide-react";
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { toast } from "sonner";
 import {
     PortfolioNameAlreadyExistsResponse,
@@ -27,11 +27,13 @@ const createPortfolioSchema = zod.object({
 export interface CreatePortfolioModalProps {
     isOpen: boolean;
     handleClose: () => void;
+    setSelectedPortfolioId: Dispatch<SetStateAction<number | null>>;
 }
 
 const CreatePortfolioModal = ({
     isOpen,
     handleClose,
+    setSelectedPortfolioId,
 }: CreatePortfolioModalProps) => {
     const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
     const [isPortfolioNameAlreadyExists, setIsPortfolioNameAlreadyExists] =
@@ -60,7 +62,7 @@ const CreatePortfolioModal = ({
         },
         onSubmit: async ({ value }) => {
             createPortfolio(value, {
-                onSuccess: () => {
+                onSuccess: ({ data }) => {
                     toast.success("Portfolio created successfully!");
                     setIsPortfolioNameAlreadyExists(false);
 
@@ -68,6 +70,12 @@ const CreatePortfolioModal = ({
                     queryClient.invalidateQueries({
                         queryKey: ["portfolio-list"],
                     });
+
+                    const portfolioId = data?.data.portfolioId;
+
+                    if (portfolioId) {
+                        setSelectedPortfolioId(portfolioId);
+                    }
 
                     handleClose();
                     form.reset();

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/CreatePortfolio/useCreatePortfolio.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/CreatePortfolio/useCreatePortfolio.test.tsx
@@ -29,7 +29,7 @@ describe("useCreatePortfolio", () => {
     it("should call POST /portfolios successfully", async () => {
         mockPostCreatePortfolio.mockResolvedValue({
             data: {
-                success: true,
+                portfolioId: 1,
             },
         });
 

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
@@ -13,10 +13,6 @@ import CreatePortfolioModal from "./components/CreatePortfolio/CreatePortfolioMo
 import { useSearchParams } from "next/navigation";
 
 export default function PortfoliosPage() {
-    const [selectedPortfolioId, setSelectedPortfolioId] = useState<
-        number | null
-    >(null);
-
     const searchParams = useSearchParams();
     const createPortfolioParam = searchParams.get("createPortfolio");
     const portfolioIdParam = searchParams.get("portfolioId");
@@ -24,19 +20,17 @@ export default function PortfoliosPage() {
     const [isCreatePortfolioModalOpen, setIsCreatePortfolioModalOpen] =
         useState(createPortfolioParam === "true");
 
+    const [selectedPortfolioId, setSelectedPortfolioId] = useState<
+        number | null
+    >(portfolioIdParam ? parseInt(portfolioIdParam) : null);
+
     const { data, isLoading } = usePortfolioList();
 
     useEffect(() => {
-        if (data && data.length > 0) {
+        if (data && data.length > 0 && !selectedPortfolioId) {
             setSelectedPortfolioId(data[0].id);
         }
-    }, [data]);
-
-    useEffect(() => {
-        if (portfolioIdParam) {
-            setSelectedPortfolioId(parseInt(portfolioIdParam));
-        }
-    }, [portfolioIdParam]);
+    }, [data, selectedPortfolioId]);
 
     return (
         <div className="items-center justify-items-center min-h-screen px-10">
@@ -84,6 +78,7 @@ export default function PortfoliosPage() {
                 <CreatePortfolioModal
                     isOpen={isCreatePortfolioModalOpen}
                     handleClose={() => setIsCreatePortfolioModalOpen(false)}
+                    setSelectedPortfolioId={setSelectedPortfolioId}
                 />
             </div>
         </div>


### PR DESCRIPTION
## Stratify UI
- Fix bug where selected portfolio id is overridden when navigating to the portfolios page from the top performers table for the first time
- Change functionality on successfully creating a portfolio to set the selected portfolio id to the newly created portfolio
## Stratify API
- Return ID of newly created portfolio instead of a success boolean flag