### PR TITLE
Add workflow to deploy to production using the release tag

### DIFF
--- a/.changeset/stale-lizards-sin.md
+++ b/.changeset/stale-lizards-sin.md
@@ -1,0 +1,7 @@
+---
+"@stratify/stratify-ui": minor
+---
+
+Retrieve client-side environment variables at runtime using next-public-env and use it in all layouts
+- Allows for dynamically configuring the app without needing to rebuild the Docker image
+- Significantly speeds up the CI/CD pipeline by eliminating the need to build and push a new image for each environment as client-side env variables are injected at runtime instead of build time

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   workflow_run:
-    workflows: [Build]
+    workflows: [Docker Image Checks]
     types: completed
     branches: main
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
     stratify-api:
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -26,6 +27,7 @@ jobs:
               run: docker build -f apps/api/stratify-api/Dockerfile . -t stratify-api:ci
 
     stratify-data-api:
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -39,6 +41,7 @@ jobs:
               run: docker build -f apps/api/stratify-data-api/Dockerfile . -t stratify-data-api:ci
 
     stratify-ui:
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/ghcr-push.yml
+++ b/.github/workflows/ghcr-push.yml
@@ -115,3 +115,36 @@ jobs:
           file: apps/api/stratify-data-api/Dockerfile
           push: true
           tags: ghcr.io/kishanj22/stratify/stratify-data-api:${{ steps.package-version.outputs.VERSION }}
+  stratify-ui:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.stratify-ui == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Get package version
+        id: package-version
+        run: echo "VERSION=$(jq -r .version apps/ui/stratify-ui/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/ui/stratify-ui/Dockerfile
+          push: true
+          tags: ghcr.io/kishanj22/stratify/stratify-ui:${{ steps.package-version.outputs.VERSION }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,56 +1,59 @@
-name: Deploy to Development Environment
+name: Deploy to Production Environment
 
 on:
-    workflow_run:
-        workflows: ["Push Docker Images to GHCR"]
-        types: completed
+    workflow_dispatch:
+        inputs:
+            release_tag:
+                description: Release tag to deploy (e.g. release-05-04-2026.1)
+                required: true
+                type: string
 
 jobs:
     prepare-deployment:
         name: Prepare Deployment
         runs-on: self-hosted
         outputs:
-            latest-release-tag: ${{ steps.get_release_manifest.outputs.latest_release_tag }}
+            release-tag: ${{ steps.get_release_manifest.outputs.release_tag }}
             stratify_data_api_version: ${{ steps.get_release_manifest.outputs.stratify_data_api_version }}
             is_stratify_data_api_changed: ${{ steps.get_release_manifest.outputs.is_stratify_data_api_changed }}
             stratify_api_version: ${{ steps.get_release_manifest.outputs.stratify_api_version }}
             is_stratify_api_changed: ${{ steps.get_release_manifest.outputs.is_stratify_api_changed }}
             stratify_ui_version: ${{ steps.get_release_manifest.outputs.stratify_ui_version }}
             is_stratify_ui_changed: ${{ steps.get_release_manifest.outputs.is_stratify_ui_changed }}
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
 
-            - name: Get release manifest from latest release
+            - name: Get release manifest from specified release
               id: get_release_manifest
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RELEASE_TAG: ${{ inputs.release_tag }}
               run: |
-                  #? Get latest release
-                  latest_release=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName,body -q '.body')
-                  latest_release_json=$(echo $latest_release | jq -r '.')
+                  #? Get the release manifest from the specified release tag
+                  release=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json tagName,body -q '.body')
+                  release_json=$(echo $release | jq -r '.')
 
-                  latest_release_tag=$(echo "$latest_release_json" | jq -r '.releaseTag')
-                  latest_release_apps=$(echo "$latest_release_json" | jq -r '.apps')
+                  release_tag=$(echo "$release_json" | jq -r '.releaseTag')
+                  release_apps=$(echo "$release_json" | jq -r '.apps')
 
-                  stratify_data_api_version=$(echo "$latest_release_apps" | jq -r '.["stratify-data-api"].version')
-                  is_stratify_data_api_changed=$(echo "$latest_release_apps" | jq -r '.["stratify-data-api"].isChanged')
+                  stratify_data_api_version=$(echo "$release_apps" | jq -r '.["stratify-data-api"].version')
+                  is_stratify_data_api_changed=$(echo "$release_apps" | jq -r '.["stratify-data-api"].isChanged')
 
-                  stratify_api_version=$(echo "$latest_release_apps" | jq -r '.["stratify-api"].version')
-                  is_stratify_api_changed=$(echo "$latest_release_apps" | jq -r '.["stratify-api"].isChanged')
+                  stratify_api_version=$(echo "$release_apps" | jq -r '.["stratify-api"].version')
+                  is_stratify_api_changed=$(echo "$release_apps" | jq -r '.["stratify-api"].isChanged')
 
-                  stratify_ui_version=$(echo "$latest_release_apps" | jq -r '.["stratify-ui"].version')
-                  is_stratify_ui_changed=$(echo "$latest_release_apps" | jq -r '.["stratify-ui"].isChanged')
+                  stratify_ui_version=$(echo "$release_apps" | jq -r '.["stratify-ui"].version')
+                  is_stratify_ui_changed=$(echo "$release_apps" | jq -r '.["stratify-ui"].isChanged')
 
-                  echo "latest_release_tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
-                  echo "stratify_data_api_version=$stratify_data_api_version" >> "$GITHUB_OUTPUT" 
-                  echo "is_stratify_data_api_changed=$is_stratify_data_api_changed" >> "$GITHUB_OUTPUT" 
-                  echo "stratify_api_version=$stratify_api_version" >> "$GITHUB_OUTPUT" 
-                  echo "is_stratify_api_changed=$is_stratify_api_changed" >> "$GITHUB_OUTPUT" 
-                  echo "stratify_ui_version=$stratify_ui_version" >> "$GITHUB_OUTPUT" 
+                  echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+                  echo "stratify_data_api_version=$stratify_data_api_version" >> "$GITHUB_OUTPUT"
+                  echo "is_stratify_data_api_changed=$is_stratify_data_api_changed" >> "$GITHUB_OUTPUT"
+                  echo "stratify_api_version=$stratify_api_version" >> "$GITHUB_OUTPUT"
+                  echo "is_stratify_api_changed=$is_stratify_api_changed" >> "$GITHUB_OUTPUT"
+                  echo "stratify_ui_version=$stratify_ui_version" >> "$GITHUB_OUTPUT"
                   echo "is_stratify_ui_changed=$is_stratify_ui_changed" >> "$GITHUB_OUTPUT"
 
     deploy-stratify-data-api:
@@ -58,7 +61,7 @@ jobs:
         runs-on: self-hosted
         needs: prepare-deployment
         if: ${{ needs.prepare-deployment.outputs.is_stratify_data_api_changed == 'true' }}
-        environment: Development
+        environment: Production
         permissions:
             contents: read
             packages: read
@@ -93,7 +96,7 @@ jobs:
 
             - name: Deploy Stratify Data API to Coolify
               run: |
-                  coolify app update "${{ secrets.STRATIFY_DATA_API_UUID }}" --docker-tag "${{ needs.prepare-deployment.outputs.stratify_data_api_version }}" --description "${{ needs.prepare-deployment.outputs.latest-release-tag }}"
+                  coolify app update "${{ secrets.STRATIFY_DATA_API_UUID }}" --docker-tag "${{ needs.prepare-deployment.outputs.stratify_data_api_version }}" --description "${{ needs.prepare-deployment.outputs.release-tag }}"
                   coolify app restart "${{ secrets.STRATIFY_DATA_API_UUID }}"
 
     deploy-stratify-api:
@@ -101,7 +104,7 @@ jobs:
         runs-on: self-hosted
         needs: [prepare-deployment, deploy-stratify-data-api]
         if: ${{ always() && needs.prepare-deployment.outputs.is_stratify_api_changed == 'true' && needs.deploy-stratify-data-api.result != 'failure' }}
-        environment: Development
+        environment: Production
         permissions:
             contents: read
             packages: read
@@ -136,7 +139,7 @@ jobs:
 
             - name: Deploy Stratify API to Coolify
               run: |
-                  coolify app update "${{ secrets.STRATIFY_API_UUID }}" --docker-tag "${{ needs.prepare-deployment.outputs.stratify_api_version }}" --description "${{ needs.prepare-deployment.outputs.latest-release-tag }}"
+                  coolify app update "${{ secrets.STRATIFY_API_UUID }}" --docker-tag "${{ needs.prepare-deployment.outputs.stratify_api_version }}" --description "${{ needs.prepare-deployment.outputs.release-tag }}"
                   coolify app restart "${{ secrets.STRATIFY_API_UUID }}"
 
     deploy-stratify-ui:
@@ -144,11 +147,16 @@ jobs:
         runs-on: self-hosted
         needs: [prepare-deployment, deploy-stratify-api]
         if: ${{ always() && needs.prepare-deployment.outputs.is_stratify_ui_changed == 'true' && needs.deploy-stratify-api.result != 'failure' }}
-        environment: Development
+        environment: Production
         permissions:
             contents: read
             packages: read
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.release_tag }}
+
             - name: Login to Github Container Registry
               uses: docker/login-action@v3
               with:
@@ -179,5 +187,5 @@ jobs:
 
             - name: Deploy Stratify UI to Coolify
               run: |
-                  coolify app update "${{ secrets.STRATIFY_UI_UUID }}" --docker-tag "${{ needs.prepare-deployment.outputs.stratify_ui_version }}" --description "${{ needs.prepare-deployment.outputs.latest-release-tag }}"
+                  coolify app update "${{ secrets.STRATIFY_UI_UUID }}" --docker-tag "${{ needs.prepare-deployment.outputs.stratify_ui_version }}" --description "${{ needs.prepare-deployment.outputs.release-tag }}"
                   coolify app restart "${{ secrets.STRATIFY_UI_UUID }}"

--- a/apps/ui/stratify-ui/Dockerfile
+++ b/apps/ui/stratify-ui/Dockerfile
@@ -27,12 +27,6 @@ COPY --from=builder /app/out/full/ .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
-ARG NEXT_PUBLIC_API_PROXY_URL
-ENV NEXT_PUBLIC_API_PROXY_URL=${NEXT_PUBLIC_API_PROXY_URL}
-
-ARG NEXT_PUBLIC_AUTH_PROXY_URL
-ENV NEXT_PUBLIC_AUTH_PROXY_URL=${NEXT_PUBLIC_AUTH_PROXY_URL}
-
 # Required as stratify-api is listed as a dependency in the package.json for the UI
 COPY apps/api/stratify-data-api/docs/openapi.json apps/api/stratify-data-api/docs/openapi.json
 
@@ -40,12 +34,6 @@ RUN pnpm build
 
 FROM base AS runner
 WORKDIR /app
-
-ARG STRATIFY_API_URL
-ENV STRATIFY_API_URL=${STRATIFY_API_URL}
-
-ARG STRATIFY_AUTH_URL
-ENV STRATIFY_AUTH_URL=${STRATIFY_AUTH_URL}
 
 # Don't run production as root
 RUN addgroup --system --gid 1001 nodejs && \

--- a/apps/ui/stratify-ui/app/(screens)/(auth)/layout.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/(auth)/layout.tsx
@@ -4,6 +4,7 @@ import Providers from "../../global/Providers";
 import { getFontClassNames } from "@/lib/fonts";
 import { Toaster } from "@/app/components/ui/sonner";
 import PublicNavbar from "@/app/components/(public)/PublicNavbar/PublicNavbar";
+import { PublicEnv } from "@/public-env";
 
 export const metadata: Metadata = {
     title: "Stratify UI",
@@ -15,18 +16,14 @@ interface AuthLayoutProps {
 }
 
 export default function AuthLayout({ children }: AuthLayoutProps) {
-    const apiProxyUrl = process.env.NEXT_PUBLIC_API_PROXY_URL || "";
-    const authProxyUrl = process.env.NEXT_PUBLIC_AUTH_PROXY_URL || "";
     const fontClassNames = getFontClassNames();
 
     return (
         <html lang="en">
             <head />
             <body className={`${fontClassNames} antialiased`} id="root">
-                <Providers
-                    apiProxyUrl={apiProxyUrl}
-                    authProxyUrl={authProxyUrl}
-                >
+                <PublicEnv />
+                <Providers>
                     <div className="h-screen flex flex-col">
                         <PublicNavbar showLoginSignUpButtons={false} />
                         <div className="flex-1 overflow-hidden">{children}</div>

--- a/apps/ui/stratify-ui/app/(screens)/(public)/layout.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/(public)/layout.tsx
@@ -3,6 +3,7 @@ import "../../globals.css";
 import Providers from "../../global/Providers";
 import PublicNavbar from "../../components/(public)/PublicNavbar/PublicNavbar";
 import { getFontClassNames } from "@/lib/fonts";
+import { PublicEnv } from "@/public-env";
 
 export const metadata: Metadata = {
     title: "Stratify UI",
@@ -14,18 +15,14 @@ interface RootLayoutProps {
 }
 
 export default function RootLayout({ children }: RootLayoutProps) {
-    const apiProxyUrl = process.env.NEXT_PUBLIC_API_PROXY_URL || "";
-    const authProxyUrl = process.env.NEXT_PUBLIC_AUTH_PROXY_URL || "";
     const fontClassNames = getFontClassNames();
 
     return (
         <html lang="en">
             <head />
             <body className={`${fontClassNames} antialiased`} id="root">
-                <Providers
-                    apiProxyUrl={apiProxyUrl}
-                    authProxyUrl={authProxyUrl}
-                >
+                <PublicEnv />
+                <Providers>
                     <PublicNavbar />
                     {children}
                 </Providers>

--- a/apps/ui/stratify-ui/app/(screens)/app/layout.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/layout.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "@/app/components/ui/sonner";
 import { SessionProvider } from "./SessionProvider";
 import AppNavbar from "@/app/components/(app)/AppNavbar";
 import { TooltipProvider } from "@/app/components/ui/tooltip";
+import { PublicEnv } from "@/public-env";
 
 export const metadata: Metadata = {
     title: "Stratify UI",
@@ -17,18 +18,14 @@ interface AuthLayoutProps {
 }
 
 export default function AppLayout({ children }: AuthLayoutProps) {
-    const apiProxyUrl = process.env.NEXT_PUBLIC_API_PROXY_URL || "";
-    const authProxyUrl = process.env.NEXT_PUBLIC_AUTH_PROXY_URL || "";
     const fontClassNames = getFontClassNames();
 
     return (
         <html lang="en">
             <head />
             <body className={`${fontClassNames} antialiased`} id="root">
-                <Providers
-                    apiProxyUrl={apiProxyUrl}
-                    authProxyUrl={authProxyUrl}
-                >
+                <PublicEnv />
+                <Providers>
                     <SessionProvider>
                         <div className="h-screen flex flex-col">
                             <AppNavbar />

--- a/apps/ui/stratify-ui/app/global/EnvironmentProvider.tsx
+++ b/apps/ui/stratify-ui/app/global/EnvironmentProvider.tsx
@@ -28,12 +28,12 @@ export const EnvironmentProvider = ({
         [apiProxyUrl, authProxyUrl],
     );
 
-    const environmentProviderValues = {
-        envVariables,
-    };
-
     return (
-        <EnvironmentContext.Provider value={environmentProviderValues}>
+        <EnvironmentContext.Provider
+            value={{
+                envVariables,
+            }}
+        >
             {children}
         </EnvironmentContext.Provider>
     );

--- a/apps/ui/stratify-ui/app/global/Providers.tsx
+++ b/apps/ui/stratify-ui/app/global/Providers.tsx
@@ -3,25 +3,18 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { EnvironmentProvider } from "./EnvironmentProvider";
 import { getQueryClient } from "./get-query-client";
-import { PropsWithChildren, Suspense } from "react";
+import { ReactNode, Suspense } from "react";
+import { getPublicEnv } from "@/public-env";
 
-interface Providers {
-    apiProxyUrl: string;
-    authProxyUrl: string;
-}
-
-export default function Providers({
-    children,
-    apiProxyUrl,
-    authProxyUrl,
-}: PropsWithChildren<Providers>) {
+export default function Providers({ children }: { children: ReactNode }) {
     const queryClient = getQueryClient();
+    const publicEnv = getPublicEnv();
 
     return (
         <Suspense>
             <EnvironmentProvider
-                apiProxyUrl={apiProxyUrl}
-                authProxyUrl={authProxyUrl}
+                apiProxyUrl={publicEnv.STRATIFY_API_PROXY_URL}
+                authProxyUrl={publicEnv.STRATIFY_AUTH_PROXY_URL}
             >
                 <QueryClientProvider client={queryClient}>
                     {children}

--- a/apps/ui/stratify-ui/package.json
+++ b/apps/ui/stratify-ui/package.json
@@ -40,6 +40,7 @@
         "ky": "^1.14.2",
         "lucide-react": "^0.553.0",
         "next": "15.5.9",
+        "next-public-env": "^1.1.0",
         "next-themes": "^0.4.6",
         "openapi-fetch": "^0.15.0",
         "radix-ui": "^1.4.3",

--- a/apps/ui/stratify-ui/public-env.ts
+++ b/apps/ui/stratify-ui/public-env.ts
@@ -10,7 +10,5 @@ export const { getPublicEnv, PublicEnv } = createPublicEnv(
             STRATIFY_API_PROXY_URL: z.string(),
             STRATIFY_AUTH_PROXY_URL: z.string(),
         }),
-        validateAtBuildStep: true,
-        
     },
 );

--- a/apps/ui/stratify-ui/public-env.ts
+++ b/apps/ui/stratify-ui/public-env.ts
@@ -1,0 +1,16 @@
+import { createPublicEnv } from "next-public-env";
+
+export const { getPublicEnv, PublicEnv } = createPublicEnv(
+    {
+        STRATIFY_API_PROXY_URL: process.env.STRATIFY_API_PROXY_URL,
+        STRATIFY_AUTH_PROXY_URL: process.env.STRATIFY_AUTH_PROXY_URL,
+    },
+    {
+        schema: (z) => ({
+            STRATIFY_API_PROXY_URL: z.string(),
+            STRATIFY_AUTH_PROXY_URL: z.string(),
+        }),
+        validateAtBuildStep: true,
+        
+    },
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       next:
         specifier: 15.5.9
         version: 15.5.9(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-public-env:
+        specifier: ^1.1.0
+        version: 1.1.0(next@15.5.9(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(zod@4.2.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4896,6 +4899,14 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-public-env@1.1.0:
+    resolution: {integrity: sha512-LNgnYoPLuJtCO8nXVGq8TXZ6A3Ndb1s7sQQTtaF+PnYXw+qoN02BTqxSjmK+Bm9AW2xpqxkbBF0UNT6is+ps6g==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -11348,6 +11359,12 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  next-public-env@1.1.0(next@15.5.9(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(zod@4.2.1):
+    dependencies:
+      next: 15.5.9(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      zod: 4.2.1
 
   next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Stratify UI
Retrieve client-side environment variables at runtime using next-public-env and use it in all layouts
- Allows for dynamically configuring the app without needing to rebuild the Docker image
- Significantly speeds up the CI/CD pipeline by eliminating the need to build and push a new image for each environment as client-side env variables are injected at runtime instead of build time