### PR TITLE
Add tooltip content

### DIFF
--- a/.changeset/nine-owls-buy.md
+++ b/.changeset/nine-owls-buy.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-api": patch
+---
+
+Retrieve 20 assets instead of just 10 for the top gainers so that the top gainers table can show more assets

--- a/.changeset/ninety-grapes-fix.md
+++ b/.changeset/ninety-grapes-fix.md
@@ -1,0 +1,6 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+- Add content to tooltips on the portfolios page, including a table breaking down how the risk label is determined
+- Fix formatting of numeric values in tables

--- a/apps/api/stratify-api/src/routes/data/market/top-gainers.get.ts
+++ b/apps/api/stratify-api/src/routes/data/market/top-gainers.get.ts
@@ -40,8 +40,7 @@ export default function topGainersGet(fastify: FastifyInstance) {
                     .GET("/market/top-gainers", {
                         params: {
                             query: {
-                                limit: 10,
-                                minimumVolume: 2000000, // 2 million volume
+                                limit: 20,
                             },
                         },
                     })

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/TopPerformersCard/topInvestmentsTableColumns.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/TopPerformersCard/topInvestmentsTableColumns.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/app/components/ui/tooltip";
 import { InfoIcon } from "lucide-react";
 import Link from "next/link";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
 
 export const columns = (userCurrency: string): ColumnDef<Investment>[] => [
     {
@@ -79,8 +80,10 @@ export const columns = (userCurrency: string): ColumnDef<Investment>[] => [
                                 side="right"
                                 className="font-semibold"
                             >
-                                {currentAssetCurrencyValue.toLocaleString()}{" "}
-                                {`(${assetCurrency})`}
+                                {formatNumericValue(
+                                    currentAssetCurrencyValue,
+                                    assetCurrency,
+                                )}
                             </TooltipContent>
                         </Tooltip>
                     ) : null}

--- a/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/MarketDataTable.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/MarketDataTable.test.tsx
@@ -154,7 +154,7 @@ describe("MarketDataTable", () => {
             expect(screen.getByText(header)).toBeInTheDocument();
         });
 
-        expect(screen.getAllByTestId("skeleton-row")).toHaveLength(5);
+        expect(screen.getAllByTestId("skeleton-row")).toHaveLength(10);
     });
 
     it("renders no data message when there is no data", () => {

--- a/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/MarketDataTable.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/MarketDataTable.tsx
@@ -78,6 +78,11 @@ const MarketDataTable = ({ selectedTab }: MarketDataTableProps) => {
                 data={data}
                 isLoading={isLoading}
                 key={selectedTab}
+                initialPaginationState={{
+                    pageIndex: 0,
+                    pageSize: 10,
+                }}
+                isLoadingRowCount={10}
             />
         </div>
     );

--- a/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/marketDataTableColumns.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/markets/MarketDataTable/marketDataTableColumns.tsx
@@ -5,6 +5,7 @@ import AssetBadge, {
     marketStateMap,
 } from "@/app/components/(app)/AssetBadge";
 import Link from "next/link";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
 
 export const columns: ColumnDef<TopAsset>[] = [
     {
@@ -54,14 +55,11 @@ export const columns: ColumnDef<TopAsset>[] = [
                 row.original.priceDetails.currentPrice ?? "---";
             const currency = row.original.currency ?? "---";
 
-            const formattedPrice =
-                typeof currentPrice === "number"
-                    ? parseFloat(currentPrice.toFixed(2)).toLocaleString()
-                    : currentPrice;
-
             return (
-                <span className="flex flex-row justify-end">
-                    {formattedPrice} {`(${currency})`}
+                <span className="flex justify-end">
+                    {typeof currentPrice === "number"
+                        ? formatNumericValue(currentPrice, currency)
+                        : currentPrice}
                 </span>
             );
         },

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AssetAllocationCard/AssetAllocationCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AssetAllocationCard/AssetAllocationCard.tsx
@@ -27,12 +27,26 @@ const AssetAllocationCard = ({ portfolioId }: AssetAllocationCardProps) => {
                 <div>Asset Allocation</div>
                 <Tooltip>
                     <TooltipTrigger>
-                        <InfoIcon className="w-4 h-4 text-primary-darker" />
+                        <InfoIcon size={20} className="text-primary-darker" />
                         <TooltipContent
-                            className="bg-secondary-lighter text-secondary-dark"
+                            className="bg-secondary-lighter text-secondary-dark text-sm font-medium w-52"
                             arrowClassName="bg-secondary-lighter fill-secondary-lighter"
+                            side="bottom"
                         >
-                            <p className="text-sm">Asset allocation tooltip</p>
+                            <div className="flex flex-col gap-y-2">
+                                <span>
+                                    How your investments are distributed across
+                                    different asset classes, countries and
+                                    sectors to understand how diversified your
+                                    portfolio is.
+                                </span>
+                                <span>
+                                    A portfolio with good diversification
+                                    typically has investments spread across
+                                    multiple asset classes, sectors and
+                                    countries, which helps reduce risk.
+                                </span>
+                            </div>
                         </TooltipContent>
                     </TooltipTrigger>
                 </Tooltip>

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/InvestmentsTable/investmentsTableColumns.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/InvestmentsTable/investmentsTableColumns.tsx
@@ -10,6 +10,7 @@ import {
 import { InfoIcon } from "lucide-react";
 import { Dispatch, SetStateAction } from "react";
 import Link from "next/link";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
 
 export const columns = (
     userCurrency: string,
@@ -93,8 +94,10 @@ export const columns = (
                                 side="right"
                                 className="font-semibold"
                             >
-                                {currentAssetCurrencyValue.toLocaleString()}{" "}
-                                {`(${assetCurrency})`}
+                                {formatNumericValue(
+                                    currentAssetCurrencyValue,
+                                    assetCurrency,
+                                )}
                             </TooltipContent>
                         </Tooltip>
                     ) : null}

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetricCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetricCard.tsx
@@ -4,6 +4,7 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from "@/app/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import { InfoIcon } from "lucide-react";
 
 interface PortfolioMetricCardProps {
@@ -11,6 +12,7 @@ interface PortfolioMetricCardProps {
     tooltipContent: React.ReactNode;
     isLoading: boolean;
     children: React.ReactNode;
+    tooltipContentSide?: "top" | "right" | "bottom" | "left";
 }
 
 const PortfolioMetricCard = ({
@@ -18,6 +20,7 @@ const PortfolioMetricCard = ({
     tooltipContent,
     isLoading,
     children,
+    tooltipContentSide = "right",
 }: PortfolioMetricCardProps) => {
     return (
         <div className="bg-secondary-lightest rounded-xl py-2.5 px-3 border border-primary-dark font-sans">
@@ -34,9 +37,23 @@ const PortfolioMetricCard = ({
                 </span>
                 <Tooltip>
                     <TooltipTrigger data-testid="portfolio-metric-card-info-icon">
-                        <InfoIcon className="size-4 text-primary-darker" />
+                        <InfoIcon size={20} className="text-primary-darker" />
                     </TooltipTrigger>
-                    <TooltipContent side="right" className="font-semibold">
+                    <TooltipContent
+                        side={tooltipContentSide}
+                        className={cn(
+                            "font-medium text-sm bg-secondary-lighter text-secondary-dark",
+                            (tooltipContentSide === "bottom" ||
+                                tooltipContentSide === "top") &&
+                                "mr-10",
+                        )}
+                        arrowClassName={cn(
+                            "bg-secondary-lighter fill-secondary-lighter",
+                            (tooltipContentSide === "bottom" ||
+                                tooltipContentSide === "top") &&
+                                "ml-10",
+                        )}
+                    >
                         {tooltipContent}
                     </TooltipContent>
                 </Tooltip>

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetrics.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetrics.tsx
@@ -35,7 +35,7 @@ interface RiskLabelTooltipContentProps {
 const RiskLabelTooltipContent = ({
     riskLevel,
 }: RiskLabelTooltipContentProps) => (
-    <div className="flex flex-col gap-y-1 text-wrap">
+    <div className="flex flex-col gap-y-1">
         <div className="grid grid-cols-3 gap-y-1 text-secondary-dark text-sm font-medium text-center">
             <div className="col-span-3 grid grid-cols-subgrid border-b border-b-secondary-light font-semibold pb-1">
                 <span>Risk level</span>

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetrics.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetrics.tsx
@@ -5,7 +5,17 @@ import {
     PortfolioMetricsResponse,
     usePortfolioMetrics,
 } from "./usePortfolioMetrics";
-import { ChartColumnDecreasing, ChartColumnIncreasing } from "lucide-react";
+import {
+    ChartColumnDecreasing,
+    ChartColumnIncreasing,
+    InfoIcon,
+} from "lucide-react";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/app/components/ui/tooltip";
 
 const riskLevelLabelMap = {
     low: "Low",
@@ -17,6 +27,73 @@ const riskLevelLabelMap = {
     PortfolioMetricsResponse["riskMetrics"]["riskLevel"],
     string
 >;
+
+interface RiskLabelTooltipContentProps {
+    riskLevel: PortfolioMetricsResponse["riskMetrics"]["riskLevel"];
+}
+
+const RiskLabelTooltipContent = ({
+    riskLevel,
+}: RiskLabelTooltipContentProps) => (
+    <div className="flex flex-col gap-y-1 text-wrap">
+        <div className="grid grid-cols-3 gap-y-1 text-secondary-dark text-sm font-medium text-center">
+            <div className="col-span-3 grid grid-cols-subgrid border-b border-b-secondary-light font-semibold pb-1">
+                <span>Risk level</span>
+                <span>Volatility</span>
+                <span>Sortino ratio</span>
+            </div>
+            <div
+                className={cn(
+                    "col-span-3 grid grid-cols-subgrid py-0.5",
+                    riskLevel === "low" &&
+                        "bg-positive-lighter border border-positive-base rounded-lg",
+                )}
+            >
+                <span>Low</span>
+                <span>&lt; 15%</span>
+                <span>&gt;= 1</span>
+            </div>
+            <div
+                className={cn(
+                    "col-span-3 grid grid-cols-subgrid py-0.5",
+                    riskLevel === "medium" &&
+                        "bg-accent-lighter border border-accent-base rounded-lg",
+                )}
+            >
+                <span>Medium</span>
+                <span>15% - 25%</span>
+                <span>&gt;= 1</span>
+            </div>
+            <div
+                className={cn(
+                    "col-span-3 grid grid-cols-subgrid py-0.5",
+                    riskLevel === "high" &&
+                        "bg-negative-lighter border border-negative-base rounded-lg",
+                )}
+            >
+                <span>High</span>
+                <span>25% - 45%</span>
+                <span>&gt;= 1</span>
+            </div>
+            <div
+                className={cn(
+                    "col-span-3 grid grid-cols-subgrid py-0.5",
+                    riskLevel === "veryHigh" &&
+                        "bg-negative-lighter border border-negative-darker rounded-lg",
+                )}
+            >
+                <span>Very high</span>
+                <span>&gt;= 45%</span>
+                <span>&lt; 1</span>
+            </div>
+        </div>
+        <div className="text-secondary-dark text-xs italic">
+            If the Sortino ratio is greater than 2, then the risk level is
+            reduced by one level. The opposite applies if the Sortino ratio is
+            below 1.
+        </div>
+    </div>
+);
 
 interface PortfolioMetricsProps {
     portfolioId: number | null;
@@ -32,7 +109,8 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
             <PortfolioMetricCard
                 title="Overall return"
                 isLoading={isLoading}
-                tooltipContent="Overall return for the portfolio"
+                tooltipContent="Total return of your portfolio, including realised and unrealised gains and losses."
+                tooltipContentSide="top"
             >
                 {data?.overallReturn ? (
                     <div
@@ -45,8 +123,10 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
                     >
                         <span>
                             {data.overallReturn.absolute >= 0 ? "+" : ""}
-                            {data.overallReturn.absolute.toLocaleString()} (
-                            {userCurrency})
+                            {formatNumericValue(
+                                data.overallReturn.absolute,
+                                userCurrency,
+                            )}
                         </span>
                         <div className="flex flex-row items-center gap-x-1">
                             {data.overallReturn.percentage >= 0 ? (
@@ -71,12 +151,41 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
             <PortfolioMetricCard
                 title="Overall risk"
                 isLoading={isLoading}
-                tooltipContent="Overall risk for the portfolio"
+                tooltipContent="An overall risk assessment of your portfolio based on its volatility and Sortino ratio."
+                tooltipContentSide="top"
             >
                 {data?.riskMetrics ? (
-                    <div className="flex flex-col items-center font-sans font-medium text-lg text-secondary-dark">
+                    <div className="flex flex-col items-center font-sans font-medium text-xl leading-6 text-secondary-dark">
                         <div className="flex flex-row items-center justify-between w-full">
-                            <span>Portfolio volatility</span>
+                            <div className="flex flex-row gap-x-1 items-center">
+                                <span>Portfolio volatility</span>
+                                <Tooltip>
+                                    <TooltipTrigger data-testid="portfolio-metric-card-info-icon">
+                                        <InfoIcon
+                                            size={20}
+                                            className="text-secondary-darker"
+                                        />
+                                    </TooltipTrigger>
+                                    <TooltipContent
+                                        side="top"
+                                        className="bg-secondary-lighter w-48"
+                                        arrowClassName="bg-secondary-lighter fill-secondary-lighter"
+                                    >
+                                        <div className="flex flex-col gap-y-2 text-secondary-dark font-medium text-sm">
+                                            <span>
+                                                A measure of how much the value
+                                                of your portfolio fluctuates.
+                                            </span>
+                                            <span>
+                                                A high volatility means that the
+                                                value can change a lot over
+                                                short time periods, which can
+                                                indicate higher risk.
+                                            </span>
+                                        </div>
+                                    </TooltipContent>
+                                </Tooltip>
+                            </div>
                             <span>
                                 {data.riskMetrics.riskLevel !== "unknown"
                                     ? `${data.riskMetrics.volatility}%`
@@ -84,7 +193,42 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
                             </span>
                         </div>
                         <div className="flex flex-row items-center justify-between w-full">
-                            <span>Sortino ratio</span>
+                            <div className="flex flex-row gap-x-1 items-center">
+                                <span>Sortino ratio</span>
+                                <Tooltip>
+                                    <TooltipTrigger data-testid="portfolio-metric-card-info-icon">
+                                        <InfoIcon
+                                            size={20}
+                                            className="text-secondary-darker"
+                                        />
+                                    </TooltipTrigger>
+                                    <TooltipContent
+                                        side="top"
+                                        className="bg-secondary-lighter w-52"
+                                        arrowClassName="bg-secondary-lighter fill-secondary-lighter"
+                                    >
+                                        <div className="flex flex-col gap-y-2 text-secondary-dark font-medium text-sm">
+                                            <span>
+                                                A measure of how well your
+                                                portfolio performs relative to
+                                                the risk of your investments
+                                                losing value.
+                                            </span>
+                                            <span>
+                                                A ratio above 1 indicates that
+                                                your portfolio is performing
+                                                well relative to the risk taken.
+                                            </span>
+                                            <span>
+                                                A ratio below 1 may mean that
+                                                the returns of your portfolio do
+                                                not justify the risk of the
+                                                investments losing value.
+                                            </span>
+                                        </div>
+                                    </TooltipContent>
+                                </Tooltip>
+                            </div>
                             <span>
                                 {data.riskMetrics.riskLevel !== "unknown"
                                     ? data.riskMetrics.sortinoRatio
@@ -107,7 +251,25 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
                                     "text-muted-dark",
                             )}
                         >
-                            <span>Risk level</span>
+                            <div className="flex flex-row gap-x-1 items-center">
+                                <span>Risk level</span>
+                                <Tooltip>
+                                    <TooltipTrigger data-testid="portfolio-metric-card-info-icon">
+                                        <InfoIcon size={20} />
+                                    </TooltipTrigger>
+                                    <TooltipContent
+                                        side="top"
+                                        className="bg-secondary-lighter w-64 flex flex-col"
+                                        arrowClassName="bg-secondary-lighter fill-secondary-lighter"
+                                    >
+                                        <RiskLabelTooltipContent
+                                            riskLevel={
+                                                data.riskMetrics.riskLevel
+                                            }
+                                        />
+                                    </TooltipContent>
+                                </Tooltip>
+                            </div>
                             <span>
                                 {data.riskMetrics.riskLevel !== "unknown"
                                     ? riskLevelLabelMap[

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueDetails.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueDetails.tsx
@@ -8,7 +8,11 @@ import {
     ChartColumnIncreasing,
     InfoIcon,
 } from "lucide-react";
-import { Tooltip } from "@/app/components/ui/tooltip";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/app/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 const changeInDateRangeLabel = {
@@ -56,10 +60,20 @@ const PortfolioValueDetails = ({
                 <div className="flex flex-row items-center gap-x-1.5">
                     <span>Portfolio value</span>
                     <Tooltip>
-                        <InfoIcon
-                            size={20}
-                            className="text-primary-dark mt-1"
-                        />
+                        <TooltipTrigger>
+                            <InfoIcon
+                                size={20}
+                                className="text-primary-dark mt-1"
+                            />
+                        </TooltipTrigger>
+                        <TooltipContent
+                            side="right"
+                            className="font-medium text-primary-lightest text-sm w-72"
+                        >
+                            The total value of your portfolio based on the
+                            investments you currently hold and their current
+                            prices.
+                        </TooltipContent>
                     </Tooltip>
                 </div>
                 <HistoryDateRangeSelector

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
@@ -66,7 +66,7 @@ export default function PortfoliosPage() {
                             />
                         </div>
                     </div>
-                    <div className="flex flex-col">
+                    <div className="flex flex-col mt-2">
                         <div className="flex flex-row items-center justify-between">
                             <div className="font-sans text-3xl text-primary-base font-semibold">
                                 Investments

--- a/apps/ui/stratify-ui/app/components/ui/tooltip.tsx
+++ b/apps/ui/stratify-ui/app/components/ui/tooltip.tsx
@@ -49,7 +49,7 @@ function TooltipContent({
                 data-slot="tooltip-content"
                 sideOffset={sideOffset}
                 className={cn(
-                    "bg-primary-base font-sans text-primary-lightest animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+                    "bg-primary-base font-sans text-primary-lightest animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs",
                     className,
                 )}
                 {...props}

--- a/apps/ui/stratify-ui/app/utils/formatNumericValue.ts
+++ b/apps/ui/stratify-ui/app/utils/formatNumericValue.ts
@@ -3,12 +3,13 @@
 export const formatNumericValue = (
     value: number,
     currency?: string,
+    fracDigits = 2,
     locale = "en",
 ) => {
-    const fractionDigits = Number.isInteger(value) ? 0 : 2;
+    const fractionDigits = Number.isInteger(value) ? 0 : fracDigits;
     const formattedValue = value.toLocaleString(locale, {
         minimumFractionDigits: fractionDigits,
-        maximumFractionDigits: 2,
+        maximumFractionDigits: fractionDigits,
     });
 
     return currency ? `${formattedValue} (${currency})` : formattedValue;


### PR DESCRIPTION
## Stratify UI
- Add content to tooltips on the portfolios page, including a table breaking down how the risk label is determined
- Fix formatting of numeric values in tables
## Stratify API
Retrieve 20 assets instead of just 10 for the top gainers so that the top gainers table can show more assets