### PR TITLE
Display 5 top performing investments max and placeholder value change label if the percentage change in the time period is null

### DIFF
--- a/.changeset/cute-fans-cover.md
+++ b/.changeset/cute-fans-cover.md
@@ -1,0 +1,9 @@
+---
+"@stratify/stratify-api": patch
+"@stratify/stratify-ui": patch
+---
+
+- Only show the top 5 performing investments in the top performers table
+- Modify return schema to return either a number or null for absolute and percentage values
+- Display placeholder value change label if the percentage change is null
+- Add unit test to ensure that the placeholder value change label is displayed when the percentage change is null

--- a/apps/api/stratify-api/src/routes/portfolios/overview/overview.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/overview/overview.get.ts
@@ -60,11 +60,11 @@ const calculateChangeInTimePeriod = (
         (entry) => new Date(entry.date).getTime() >= startDate.getTime(),
     );
 
-    if (!startValueEntry) {
+    if (!startValueEntry || startValueEntry.portfolioValue === 0) {
         return {
-            absolute: 0,
-            percentage: 0,
-        };
+            absolute: null,
+            percentage: null,
+        } satisfies Return;
     }
 
     const valueDifference = latestValue - startValueEntry.portfolioValue;
@@ -74,7 +74,7 @@ const calculateChangeInTimePeriod = (
         percentage: toTwoDecimalPoints(
             (valueDifference / startValueEntry.portfolioValue) * 100,
         ),
-    };
+    } satisfies Return;
 };
 
 const retrieveOverviewDetails = async (portfolioIds: number[]) => {
@@ -128,9 +128,9 @@ const retrieveOverviewDetails = async (portfolioIds: number[]) => {
         percentage: toTwoDecimalPoints((overallReturn / totalBuyAmount) * 100),
     } satisfies Return;
 
-    const currentInvestments = investments.filter(
-        (investment) => investment.currentValue > 0,
-    );
+    const currentInvestments = investments
+        .filter((investment) => investment.currentValue > 0)
+        .sort((a, b) => b.currentReturnPercentage - a.currentReturnPercentage);
 
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
@@ -153,9 +153,7 @@ const retrieveOverviewDetails = async (portfolioIds: number[]) => {
             ),
             allTime: allTimeReturn,
         },
-        investments: currentInvestments.sort(
-            (a, b) => b.currentReturnPercentage - a.currentReturnPercentage,
-        ),
+        investments: currentInvestments,
     } satisfies Overview;
 };
 

--- a/apps/api/stratify-api/src/schemas/common-schemas.ts
+++ b/apps/api/stratify-api/src/schemas/common-schemas.ts
@@ -23,8 +23,8 @@ export type MarketState = Static<typeof marketStateSchema>;
 export type AssetType = Static<typeof assetTypeSchema>;
 
 export const returnSchema = Type.Object({
-    percentage: Type.Number(),
-    absolute: Type.Number(),
+    percentage: Type.Union([Type.Number(), Type.Null()]),
+    absolute: Type.Union([Type.Number(), Type.Null()]),
 });
 
 export type Return = Static<typeof returnSchema>;

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/OverallChangeCard.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/OverallChangeCard.test.tsx
@@ -80,4 +80,22 @@ describe("OverallChangeCard", () => {
         ).toBeInTheDocument();
         expect(screen.getByTestId("chart-column")).toBeInTheDocument();
     });
+
+    it("should render placeholder values when there is a null value", () => {
+        renderComponent({
+            overallChange: {
+                ...defaultProps.overallChange,
+                lastThirtyDays: {
+                    absolute: null,
+                    percentage: null,
+                },
+            },
+        });
+
+        const emptyValues = screen.getAllByText("---");
+        expect(emptyValues).toHaveLength(1);
+
+        const chartColumn = screen.getByTestId("chart-column-not-found");
+        expect(chartColumn).toBeInTheDocument();
+    });
 });

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/OverallChangeCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/OverallChangeCard.tsx
@@ -4,7 +4,7 @@ import KeyPerformanceCard from "./KeyPerformanceCard";
 import ValueChangeLabel from "./ValueChangeLabel";
 
 export interface OverallChangeCardProps {
-    overallChange: Overview["overallChange"];
+    overallChange?: Overview["overallChange"];
     isLoading: boolean;
     isInvestmentsNotFoundError: boolean;
     isPortfoliosNotFoundError: boolean;
@@ -44,7 +44,7 @@ const OverallChangeCard = ({
                         </span>
                         <ValueChangeLabel
                             valueChangePercent={
-                                overallChange?.lastThirtyDays.percentage
+                                overallChange?.lastThirtyDays.percentage ?? null
                             }
                             isNotFoundError={
                                 isInvestmentsNotFoundError ||
@@ -58,7 +58,7 @@ const OverallChangeCard = ({
                         </span>
                         <ValueChangeLabel
                             valueChangePercent={
-                                overallChange?.lastSixMonths.percentage
+                                overallChange?.lastSixMonths.percentage ?? null
                             }
                             isNotFoundError={
                                 isInvestmentsNotFoundError ||
@@ -72,7 +72,7 @@ const OverallChangeCard = ({
                         </span>
                         <ValueChangeLabel
                             valueChangePercent={
-                                overallChange?.allTime.percentage
+                                overallChange?.allTime.percentage ?? null
                             }
                             isNotFoundError={
                                 isInvestmentsNotFoundError ||

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/OverallChangeCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/OverallChangeCard.tsx
@@ -4,7 +4,7 @@ import KeyPerformanceCard from "./KeyPerformanceCard";
 import ValueChangeLabel from "./ValueChangeLabel";
 
 export interface OverallChangeCardProps {
-    overallChange?: Overview["overallChange"];
+    overallChange: Overview["overallChange"];
     isLoading: boolean;
     isInvestmentsNotFoundError: boolean;
     isPortfoliosNotFoundError: boolean;

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/TopPerformersCard/TopPerformersTable.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/TopPerformersCard/TopPerformersTable.tsx
@@ -26,10 +26,11 @@ const TopPerformersTable = ({
     isPortfoliosNotFoundError,
     isInvestmentsNotFoundError,
 }: TopPerformersCardProps) => {
-    const filteredInvestments =
-        investments?.filter((investment) => investment.currentReturn > 0) ?? [];
+    const investmentsWithPositiveReturn = investments
+        .filter((investment) => investment.currentReturn > 0)
+        .slice(0, 5);
 
-    const hasNoPositiveReturns = filteredInvestments.length === 0;
+    const hasNoPositiveReturns = investmentsWithPositiveReturn.length === 0;
 
     const { session } = useSessionContext();
     const userCurrency = session?.userDetails.currency as string;
@@ -40,7 +41,7 @@ const TopPerformersTable = ({
           ? noInvestmentsData("No investments found")
           : hasNoPositiveReturns
             ? noInvestmentsData("No top performers found")
-            : filteredInvestments;
+            : investmentsWithPositiveReturn;
 
     const isNotFoundError =
         isPortfoliosNotFoundError ||

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/ValueChangeLabel.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/ValueChangeLabel.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 
 interface ValueChangeLabelProps {
-    valueChangePercent?: number;
+    valueChangePercent: number | null;
     isNotFoundError: boolean;
 }
 
@@ -18,7 +18,7 @@ const ValueChangeLabel = ({
     const baseClassName =
         "flex flex-row font-sans items-center text-lg gap-x-1 mt-1.5 leading-5";
 
-    if (isNotFoundError) {
+    if (isNotFoundError || valueChangePercent == null) {
         return (
             <div className={`${baseClassName} text-secondary-light`}>
                 <ChartColumn
@@ -30,39 +30,26 @@ const ValueChangeLabel = ({
         );
     }
 
-    const isPositive = valueChangePercent && valueChangePercent > 0.01;
-    const isNegative = valueChangePercent && valueChangePercent < 0;
-
-    const sign = isPositive ? "+" : "";
-
-    if (isPositive) {
-        return (
-            <div className={`${baseClassName} text-positive-base`}>
-                <ChartColumnIncreasing
-                    className="w-5 h-5"
-                    data-testid="chart-column-increasing-positive"
-                />
-                {`${sign}${valueChangePercent}%`}
-            </div>
-        );
-    }
-
-    if (isNegative) {
-        return (
-            <div className={`${baseClassName} text-negative-base`}>
-                <ChartColumnDecreasing
-                    className="w-5 h-5"
-                    data-testid="chart-column-decreasing-negative"
-                />
-                {`${valueChangePercent}%`}
-            </div>
-        );
-    }
-
-    return (
-        <div className={`${baseClassName} text-muted-dark`}>
+    return valueChangePercent === 0 ? (
+        <div className={`${baseClassName} text-secondary-light`}>
             <ChartColumn className="w-5 h-5" data-testid="chart-column" />
             {"0%"}
+        </div>
+    ) : valueChangePercent > 0 ? (
+        <div className={`${baseClassName} text-positive-base`}>
+            <ChartColumnIncreasing
+                className="w-5 h-5"
+                data-testid="chart-column-increasing-positive"
+            />
+            {`+${valueChangePercent}%`}
+        </div>
+    ) : (
+        <div className={`${baseClassName} text-negative-base`}>
+            <ChartColumnDecreasing
+                className="w-5 h-5"
+                data-testid="chart-column-decreasing-negative"
+            />
+            {`${valueChangePercent}%`}
         </div>
     );
 };

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/components/SimulationReturnItem.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/components/SimulationReturnItem.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import { CompoundingSimulatorSuccessResponse } from "../compounding/useCompoundingSimulator";
 import { Skeleton } from "@/app/components/ui/skeleton";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
 
 interface SimulationReturnItemProps {
     title: string;
@@ -15,10 +16,10 @@ const SimulationReturnItem = ({
     returnDetails,
     isLoading,
 }: SimulationReturnItemProps) => {
-    const hasPositiveReturn = returnDetails
+    const hasPositiveReturn = returnDetails?.absolute
         ? returnDetails.absolute > 0
         : false;
-    const hasNegativeReturn = returnDetails
+    const hasNegativeReturn = returnDetails?.absolute
         ? returnDetails.absolute < 0
         : false;
 
@@ -56,19 +57,19 @@ const SimulationReturnItem = ({
                         hasNegativeReturn && "text-negative-base",
                     )}
                 >
-                    <div>
-                        {returnDetails
-                            ? (hasPositiveReturn ? "+" : "") +
-                              returnDetails.absolute.toLocaleString()
-                            : "---"}
-                    </div>
-                    <div>
-                        {returnDetails
-                            ? (hasPositiveReturn ? "+" : "") +
-                              returnDetails.percentage +
-                              "%"
-                            : "---"}
-                    </div>
+                    <span>
+                        {returnDetails?.absolute == null
+                            ? "---"
+                            : (returnDetails.absolute > 0 ? "+" : "") +
+                              formatNumericValue(returnDetails.absolute)}
+                    </span>
+                    <span>
+                        {returnDetails?.percentage == null
+                            ? "---"
+                            : (returnDetails.percentage > 0 ? "+" : "") +
+                              formatNumericValue(returnDetails.percentage) +
+                              "%"}
+                    </span>
                 </div>
             )}
         </div>

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingReturnsCard.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingReturnsCard.test.tsx
@@ -33,7 +33,7 @@ describe("CompoundingReturnsCard", () => {
             expect(screen.getByText(returnValue)).toBeInTheDocument();
         });
 
-        const percentageReturns = ["0%", "+57.5%", "+90%"];
+        const percentageReturns = ["0%", "+57.50%", "+90%"];
 
         percentageReturns.forEach((returnValue) => {
             expect(screen.getByText(returnValue)).toBeInTheDocument();

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingReturnsCard.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingReturnsCard.test.tsx
@@ -29,7 +29,7 @@ describe("CostAveragingReturnsCard", () => {
             expect(screen.getByText(returnValue)).toBeInTheDocument();
         });
 
-        const percentageReturns = ["+57.5%", "+90%"];
+        const percentageReturns = ["+57.50%", "+90%"];
 
         percentageReturns.forEach((returnValue) => {
             expect(screen.getByText(returnValue)).toBeInTheDocument();

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetrics.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioMetrics/PortfolioMetrics.tsx
@@ -115,6 +115,7 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
                 {data?.overallReturn ? (
                     <div
                         className={`flex flex-row items-center justify-between font-sans font-medium text-lg ${
+                            data.overallReturn.absolute &&
                             data.overallReturn.absolute >= 0
                                 ? "text-positive-base"
                                 : "text-negative-base"
@@ -122,14 +123,20 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
                         data-testid="overall-return"
                     >
                         <span>
-                            {data.overallReturn.absolute >= 0 ? "+" : ""}
-                            {formatNumericValue(
-                                data.overallReturn.absolute,
-                                userCurrency,
-                            )}
+                            {data.overallReturn.absolute &&
+                            data.overallReturn.absolute >= 0
+                                ? "+"
+                                : ""}
+                            {data.overallReturn.absolute
+                                ? formatNumericValue(
+                                      data.overallReturn.absolute,
+                                      userCurrency,
+                                  )
+                                : "---"}
                         </span>
                         <div className="flex flex-row items-center gap-x-1">
-                            {data.overallReturn.percentage >= 0 ? (
+                            {data.overallReturn.percentage &&
+                            data.overallReturn.percentage >= 0 ? (
                                 <ChartColumnIncreasing
                                     size={22}
                                     data-testid="chart-column-increasing"
@@ -140,8 +147,15 @@ const PortfolioMetrics = ({ portfolioId }: PortfolioMetricsProps) => {
                                     data-testid="chart-column-decreasing"
                                 />
                             )}
-                            {data.overallReturn.percentage >= 0 ? "+" : ""}
-                            {data.overallReturn.percentage}%
+                            {data.overallReturn.percentage &&
+                            data.overallReturn.percentage >= 0
+                                ? "+"
+                                : ""}
+                            {data.overallReturn.percentage &&
+                                formatNumericValue(
+                                    data.overallReturn.percentage,
+                                )}
+                            %
                         </div>
                     </div>
                 ) : (


### PR DESCRIPTION
## Stratify UI
- Only show the top 5 performing investments in the top performers table
- Display placeholder value change label if the percentage change is null
- Add unit test to ensure that the placeholder value change label is displayed when the percentage change is null
## Stratify API
- Modify return schema to return either a number or null for absolute and percentage values