### PR TITLE
ab#424 Fix asset name field being set to undefined (undefined) in add investment modal

### DIFF
--- a/.changeset/quiet-waves-hide.md
+++ b/.changeset/quiet-waves-hide.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+Fix asset name field being set to undefined (undefined) when selecting an asset in the add investment modal

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AddInvestmentModal.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AddInvestmentModal.tsx
@@ -113,8 +113,6 @@ const AddInvestmentModal = ({
             onBlurAsync: async ({ value }) => {
                 const result = addInvestmentSchema.safeParse(value);
 
-                console.log("Validation result:", result);
-
                 //? If currency conversion is required but the conversion rate isn't set, then the submit button should be disabled
                 if (selectedAsset?.assetCurrency !== userCurrency) {
                     const currencyConversionRateValue =
@@ -378,10 +376,11 @@ const AddInvestmentModal = ({
                                                 preselectedAsset !== undefined
                                             }
                                             value={
-                                                field.state.value ||
                                                 preselectedAsset
                                                     ? `${preselectedAsset?.name} (${preselectedAsset?.symbol})`
-                                                    : searchValue
+                                                    : selectedAsset
+                                                      ? `${selectedAsset.name} (${selectedAsset.symbol})`
+                                                      : searchValue
                                             }
                                             onValueChange={(searchValue) =>
                                                 setSearchValue(searchValue)


### PR DESCRIPTION
- Fix asset name field being set to undefined (undefined) when selecting an asset in the add investment modal