### PR TITLE
Fix number inputs in compounding and cost-averaging simulator forms

### DIFF
--- a/.changeset/smart-moons-thank.md
+++ b/.changeset/smart-moons-thank.md
@@ -1,0 +1,7 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+- Fix number inputs in compounding and cost-averaging simulator forms so they are empty strings by default
+- Change fee field in add trade and add investment modals to default to empty string instead of 0 and pass validation as an empty string (blank is treated as 0)
+- Format subtotal, asset currency subtotal, fee and total values in add trade and add investment modals to display numeric values correctly

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingSimulatorForm.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingSimulatorForm.test.tsx
@@ -55,24 +55,6 @@ describe("CompoundingSimulatorForm", () => {
         fieldLabels.forEach((label) => {
             expect(screen.getByText(label)).toBeInTheDocument();
         });
-    });
-
-    it("should render the default values correctly", () => {
-        renderComponent();
-
-        const fieldTestIds = [
-            "initial-investment-field",
-            "monthly-contribution-field",
-            "time-period-years-field",
-        ];
-
-        fieldTestIds.forEach((testId) => {
-            within(screen.getByTestId(testId)).getByDisplayValue("0");
-        });
-    });
-
-    it("should render the submit button", () => {
-        renderComponent();
 
         expect(screen.getByText("Simulate")).toBeInTheDocument();
     });
@@ -90,27 +72,27 @@ describe("CompoundingSimulatorForm", () => {
 
         await user.click(screen.getByTestId("asset-name-card"));
 
-        const initialInvestmentInput = within(
-            screen.getByTestId("initial-investment-field"),
-        ).getByDisplayValue("0");
+        const initialInvestmentInput = screen.getByTestId(
+            "initial-investment-field-input",
+        );
         await user.clear(initialInvestmentInput);
         await user.type(initialInvestmentInput, "10000");
 
-        const monthlyContributionInput = within(
-            screen.getByTestId("monthly-contribution-field"),
-        ).getByDisplayValue("0");
+        const monthlyContributionInput = screen.getByTestId(
+            "monthly-contribution-field-input",
+        );
         await user.clear(monthlyContributionInput);
         await user.type(monthlyContributionInput, "500");
 
-        const timePeriodInput = within(
-            screen.getByTestId("time-period-years-field"),
-        ).getByDisplayValue("0");
+        const timePeriodInput = screen.getByTestId(
+            "time-period-years-field-input",
+        );
         await user.clear(timePeriodInput);
         await user.type(timePeriodInput, "20");
 
-        const dividendYieldInput = within(
-            screen.getByTestId("annual-dividend-yield-field"),
-        ).getByPlaceholderText("Optional");
+        const dividendYieldInput = screen.getByTestId(
+            "annual-dividend-yield-field-input",
+        );
         await user.clear(dividendYieldInput);
         await user.type(dividendYieldInput, "5");
 
@@ -143,27 +125,27 @@ describe("CompoundingSimulatorForm", () => {
 
         await user.click(screen.getByTestId("asset-name-card"));
 
-        const initialInvestmentInput = within(
-            screen.getByTestId("initial-investment-field"),
-        ).getByDisplayValue("0");
+        const initialInvestmentInput = screen.getByTestId(
+            "initial-investment-field-input",
+        );
         await user.clear(initialInvestmentInput);
         await user.type(initialInvestmentInput, "10000");
 
-        const monthlyContributionInput = within(
-            screen.getByTestId("monthly-contribution-field"),
-        ).getByDisplayValue("0");
+        const monthlyContributionInput = screen.getByTestId(
+            "monthly-contribution-field-input",
+        );
         await user.clear(monthlyContributionInput);
         await user.type(monthlyContributionInput, "500");
 
-        const timePeriodInput = within(
-            screen.getByTestId("time-period-years-field"),
-        ).getByDisplayValue("0");
+        const timePeriodInput = screen.getByTestId(
+            "time-period-years-field-input",
+        );
         await user.clear(timePeriodInput);
         await user.type(timePeriodInput, "20");
 
-        const dividendYieldInput = within(
-            screen.getByTestId("annual-dividend-yield-field"),
-        ).getByPlaceholderText("Optional");
+        const dividendYieldInput = screen.getByTestId(
+            "annual-dividend-yield-field-input",
+        );
         await user.clear(dividendYieldInput);
         await user.type(dividendYieldInput, "5");
 
@@ -177,7 +159,7 @@ describe("CompoundingSimulatorForm", () => {
 
         expect(mockResetSimulation).toHaveBeenCalled();
 
-        expect(screen.getAllByDisplayValue("0")).toHaveLength(3);
+        expect(screen.getAllByDisplayValue("")).toHaveLength(5);
     });
 
     it("should disable the simulate button when isPending is true", () => {
@@ -199,9 +181,9 @@ describe("CompoundingSimulatorForm", () => {
     it("should disable the simulate button when the form is invalid", async () => {
         renderComponent();
 
-        const initialInvestmentInput = within(
-            screen.getByTestId("initial-investment-field"),
-        ).getByDisplayValue("0");
+        const initialInvestmentInput = screen.getByTestId(
+            "initial-investment-field-input",
+        );
         await user.clear(initialInvestmentInput);
         await user.type(initialInvestmentInput, "-100");
 

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingSimulatorForm.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingSimulatorForm.tsx
@@ -28,9 +28,9 @@ import AssetNameCard from "../../portfolios/components/AddInvestment/AssetNameCa
 
 const defaultValues: CompoundingSimulatorSchema = {
     assetName: "",
-    initialInvestment: 0,
-    monthlyContribution: 0,
-    timePeriodYears: 0,
+    initialInvestment: "",
+    monthlyContribution: "",
+    timePeriodYears: "",
     dividendYield: "",
 };
 
@@ -94,9 +94,9 @@ const CompoundingSimulatorForm = ({
 
             const requestBody = {
                 assetId: selectedAsset.id,
-                initialInvestment: value.initialInvestment,
-                monthlyContribution: value.monthlyContribution,
-                timePeriodYears: value.timePeriodYears,
+                initialInvestment: parseFloat(value.initialInvestment),
+                monthlyContribution: parseFloat(value.monthlyContribution),
+                timePeriodYears: parseInt(value.timePeriodYears),
                 dividendYield: value.dividendYield
                     ? parseFloat(value.dividendYield)
                     : null,
@@ -229,14 +229,13 @@ const CompoundingSimulatorForm = ({
             </form.AppField>
             <div className="flex flex-row justify-between gap-x-5">
                 <form.AppField name="initialInvestment">
-                    {({ state: { meta }, NumberInput }) => {
+                    {({ state: { meta }, TextInput }) => {
                         return (
-                            <NumberInput
+                            <TextInput
                                 id="initialInvestment"
                                 dataTestId="initial-investment-field"
                                 label="Initial Investment"
-                                placeholder="Enter initial investment"
-                                type="number"
+                                placeholder="e.g. 10000"
                                 error={
                                     meta.isTouched
                                         ? meta.errors?.[0]?.message
@@ -247,13 +246,13 @@ const CompoundingSimulatorForm = ({
                     }}
                 </form.AppField>
                 <form.AppField name="monthlyContribution">
-                    {({ state: { meta }, NumberInput }) => {
+                    {({ state: { meta }, TextInput }) => {
                         return (
-                            <NumberInput
+                            <TextInput
                                 id="monthlyContribution"
                                 dataTestId="monthly-contribution-field"
                                 label="Monthly Contribution"
-                                placeholder="Enter monthly contribution"
+                                placeholder="e.g. 500"
                                 error={
                                     meta.isTouched
                                         ? meta.errors?.[0]?.message
@@ -266,13 +265,13 @@ const CompoundingSimulatorForm = ({
             </div>
             <div className="flex flex-row justify-between gap-x-5">
                 <form.AppField name="timePeriodYears">
-                    {({ state: { meta }, NumberInput }) => {
+                    {({ state: { meta }, TextInput }) => {
                         return (
-                            <NumberInput
+                            <TextInput
                                 id="timePeriodYears"
                                 dataTestId="time-period-years-field"
                                 label="Time Period (Years)"
-                                placeholder="Enter time period in years"
+                                placeholder="e.g. 5"
                                 error={
                                     meta.isTouched
                                         ? meta.errors?.[0]?.message
@@ -289,7 +288,7 @@ const CompoundingSimulatorForm = ({
                                 id="dividendYield"
                                 dataTestId="annual-dividend-yield-field"
                                 label="Annual Dividend Yield"
-                                placeholder="Optional"
+                                placeholder="e.g. 2.5 (Optional)"
                                 error={
                                     meta.isTouched
                                         ? meta.errors?.[0]?.message

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/compoundingSimulatorSchema.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/compoundingSimulatorSchema.ts
@@ -2,23 +2,29 @@ import * as zod from "zod";
 
 export const compoundingSimulatorSchema = zod.object({
     assetName: zod.string().min(1, { error: "Asset should be selected" }),
-    initialInvestment: zod
-        .number({
-            error: "Initial investment should be a number",
-        })
-        .min(0.01, { error: "Initial investment should be greater than 0" }),
-    monthlyContribution: zod
-        .number({
-            error: "Monthly contribution should be a number",
-        })
-        .min(0, {
-            error: "Monthly contribution should be greater than or equal to 0",
-        }),
-    timePeriodYears: zod
-        .number({
-            error: "Time period should be a number",
-        })
-        .min(1, { error: "Time period should be at least 1 year" }),
+    initialInvestment: zod.string().refine(
+        (value) => {
+            const numberValue = parseFloat(value);
+            return !isNaN(numberValue) && numberValue > 0;
+        },
+        {
+            error: "Initial investment should be greater than 0",
+        },
+    ),
+    monthlyContribution: zod.string().refine(
+        (value) => {
+            const numberValue = parseFloat(value);
+            return !isNaN(numberValue) && numberValue >= 0;
+        },
+        { error: "Monthly contribution should be greater than or equal to 0" },
+    ),
+    timePeriodYears: zod.string().refine(
+        (value) => {
+            const numberValue = parseInt(value);
+            return !isNaN(numberValue) && numberValue >= 1;
+        },
+        { error: "Time period should be at least 1 year" },
+    ),
     dividendYield: zod
         .string()
         .optional()

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingSimulatorForm.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingSimulatorForm.test.tsx
@@ -59,30 +59,12 @@ describe("CostAveragingSimulatorForm", () => {
         fieldLabels.forEach((label) => {
             expect(screen.getByText(label)).toBeInTheDocument();
         });
-    });
-
-    it("should render the default values correctly", () => {
-        renderComponent();
-
-        const fieldTestIds = [
-            "total-investment-field",
-            "time-period-years-field",
-            "amount-per-contribution-field",
-        ];
-
-        fieldTestIds.forEach((testId) => {
-            within(screen.getByTestId(testId)).getByDisplayValue("0");
-        });
 
         expect(
             within(
                 screen.getByTestId("contribution-frequency-select-value"),
             ).getByText("Monthly"),
         ).toBeInTheDocument();
-    });
-
-    it("should render teh submit button", () => {
-        renderComponent();
 
         expect(screen.getByText("Simulate")).toBeInTheDocument();
     });
@@ -100,15 +82,15 @@ describe("CostAveragingSimulatorForm", () => {
 
         await user.click(screen.getByTestId("asset-name-card"));
 
-        const totalInvestmentInput = within(
-            screen.getByTestId("total-investment-field"),
-        ).getByDisplayValue("0");
+        const totalInvestmentInput = screen.getByTestId(
+            "total-investment-field-input",
+        );
         await user.clear(totalInvestmentInput);
         await user.type(totalInvestmentInput, "12000");
 
-        const timePeriodInput = within(
-            screen.getByTestId("time-period-years-field"),
-        ).getByDisplayValue("0");
+        const timePeriodInput = screen.getByTestId(
+            "time-period-years-field-input",
+        );
         await user.clear(timePeriodInput);
         await user.type(timePeriodInput, "2");
         await user.tab();
@@ -148,22 +130,22 @@ describe("CostAveragingSimulatorForm", () => {
 
         await user.click(screen.getByTestId("asset-name-card"));
 
-        const totalInvestmentInput = within(
-            screen.getByTestId("total-investment-field"),
-        ).getByDisplayValue("0");
+        const totalInvestmentInput = screen.getByTestId(
+            "total-investment-field-input",
+        );
         await user.clear(totalInvestmentInput);
         await user.type(totalInvestmentInput, "12000");
 
-        const timePeriodInput = within(
-            screen.getByTestId("time-period-years-field"),
-        ).getByDisplayValue("0");
+        const timePeriodInput = screen.getByTestId(
+            "time-period-years-field-input",
+        );
         await user.clear(timePeriodInput);
         await user.type(timePeriodInput, "2");
         await user.tab();
 
-        const displayValues = ["12000", "2", "500", "Monthly"];
+        const formInputs = ["12000", "2", "500.00", "Monthly"];
 
-        displayValues.forEach((value) => {
+        formInputs.forEach((value) => {
             expect(screen.getAllByDisplayValue(value)).toHaveLength(1);
         });
 
@@ -191,9 +173,9 @@ describe("CostAveragingSimulatorForm", () => {
     it("should disable the simulate button when the form is invalid", async () => {
         renderComponent();
 
-        const totalInvestmentInput = within(
-            screen.getByTestId("total-investment-field"),
-        ).getByDisplayValue("0");
+        const totalInvestmentInput = screen.getByTestId(
+            "total-investment-field-input",
+        );
         await user.clear(totalInvestmentInput);
         await user.type(totalInvestmentInput, "-100");
 

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingSimulatorForm.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingSimulatorForm.tsx
@@ -36,10 +36,10 @@ import {
 
 const defaultValues: CostAveragingSimulatorSchema = {
     assetName: "",
-    totalInvestment: 0,
+    totalInvestment: "",
     contributionFrequency: "monthly",
-    timePeriodYears: 0,
-    amountPerContribution: 0,
+    timePeriodYears: "",
+    amountPerContribution: "",
 };
 
 const costAveragingSimulatorFormOptions = formOptions({
@@ -135,10 +135,10 @@ const CostAveragingSimulatorForm = ({
 
             const requestBody = {
                 assetId: selectedAsset.id,
-                totalInvestment: value.totalInvestment,
+                totalInvestment: parseFloat(value.totalInvestment),
                 contributionFrequency: value.contributionFrequency,
-                amountPerContribution: value.amountPerContribution,
-                timePeriodYears: value.timePeriodYears,
+                amountPerContribution: parseFloat(value.amountPerContribution),
+                timePeriodYears: parseInt(value.timePeriodYears),
             } satisfies CostAveragingSimulatorRequestSchema;
 
             executeSimulation(requestBody, {
@@ -160,18 +160,16 @@ const CostAveragingSimulatorForm = ({
     useEffect(() => {
         if (formValues.totalInvestment && formValues.timePeriodYears) {
             const totalContributions =
-                formValues.timePeriodYears *
+                parseInt(formValues.timePeriodYears) *
                 contributionFrequencyToContributionsPerYearMap[
                     formValues.contributionFrequency
                 ];
 
             form.setFieldValue(
                 "amountPerContribution",
-                parseFloat(
-                    (formValues.totalInvestment / totalContributions).toFixed(
-                        2,
-                    ),
-                ),
+                (
+                    parseFloat(formValues.totalInvestment) / totalContributions
+                ).toFixed(2),
             );
         }
     }, [
@@ -293,14 +291,13 @@ const CostAveragingSimulatorForm = ({
             </form.AppField>
             <div className="flex flex-row justify-between gap-x-5">
                 <form.AppField name="totalInvestment">
-                    {({ state: { meta }, NumberInput }) => {
+                    {({ state: { meta }, TextInput }) => {
                         return (
-                            <NumberInput
+                            <TextInput
                                 id="totalInvestment"
                                 dataTestId="total-investment-field"
                                 label="Total Investment"
-                                placeholder="Enter total investment"
-                                type="number"
+                                placeholder="e.g. 100,000"
                                 error={
                                     meta.isTouched
                                         ? meta.errors?.[0]?.message
@@ -365,13 +362,13 @@ const CostAveragingSimulatorForm = ({
             </div>
             <div className="flex flex-row justify-between gap-x-5">
                 <form.AppField name="timePeriodYears">
-                    {({ state: { meta }, NumberInput }) => {
+                    {({ state: { meta }, TextInput }) => {
                         return (
-                            <NumberInput
+                            <TextInput
                                 id="timePeriodYears"
                                 dataTestId="time-period-years-field"
                                 label="Time Period (Years)"
-                                placeholder="Enter time period in years"
+                                placeholder="e.g. 5"
                                 error={
                                     meta.isTouched
                                         ? meta.errors?.[0]?.message
@@ -382,9 +379,9 @@ const CostAveragingSimulatorForm = ({
                     }}
                 </form.AppField>
                 <form.AppField name="amountPerContribution">
-                    {({ NumberInput }) => {
+                    {({ TextInput }) => {
                         return (
-                            <NumberInput
+                            <TextInput
                                 id="amountPerContribution"
                                 dataTestId="amount-per-contribution-field"
                                 label={

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/costAveragingSimulatorSchema.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/costAveragingSimulatorSchema.ts
@@ -1,31 +1,34 @@
-
 import * as zod from "zod";
 
 export const costAveragingSimulatorSchema = zod.object({
     assetName: zod.string().min(1, { error: "Asset should be selected" }),
-    totalInvestment: zod
-        .number({
-            error: "Total investment should be a number",
-        })
-        .min(0.01, { error: "Total investment should be greater than 0" }),
+    totalInvestment: zod.string().refine(
+        (value) => {
+            const numberValue = parseFloat(value);
+            return !isNaN(numberValue) && numberValue > 0;
+        },
+        { error: "Total investment should be greater than 0" },
+    ),
     contributionFrequency: zod.enum(
         ["weekly", "monthly", "quarterly", "annually"],
         {
             error: "Contribution frequency should be selected",
         },
     ),
-    timePeriodYears: zod
-        .number({
-            error: "Time period should be a number",
-        })
-        .min(1, { error: "Time period should be at least 1 year" }),
-    amountPerContribution: zod
-        .number({
-            error: "Amount per contribution should be a number",
-        })
-        .min(0.01, {
-            error: "Amount per contribution should be greater than 0",
-        }),
+    timePeriodYears: zod.string().refine(
+        (value) => {
+            const numberValue = parseInt(value);
+            return !isNaN(numberValue) && numberValue >= 1;
+        },
+        { error: "Time period should be at least 1 year" },
+    ),
+    amountPerContribution: zod.string().refine(
+        (value) => {
+            const numberValue = parseFloat(value);
+            return !isNaN(numberValue) && numberValue > 0;
+        },
+        { error: "Amount per contribution should be greater than 0" },
+    ),
 });
 
 export type CostAveragingSimulatorSchema = zod.input<

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AddInvestmentModal.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AddInvestmentModal.tsx
@@ -46,7 +46,7 @@ const defaultValues: AddInvestmentSchema = {
     tradeDate: "",
     pricePerShare: "",
     currencyConversionRate: "1",
-    fee: "0",
+    fee: "",
     total: 0,
     assetCurrencyTotal: 0,
 };

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AddInvestmentModal.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/AddInvestmentModal.tsx
@@ -39,6 +39,7 @@ import { HTTPError } from "ky";
 import { toast } from "sonner";
 import { SelectedAsset } from "../AddTrade/AddTradeModal";
 import { useRouter } from "next/navigation";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
 
 const defaultValues: AddInvestmentSchema = {
     assetName: "",
@@ -581,7 +582,7 @@ const AddInvestmentModal = ({
                                 </span>
                                 <span className="font-medium text-muted-dark">
                                     {subtotal > 0 && userCurrency
-                                        ? `${subtotal.toFixed(2)} (${userCurrency})`
+                                        ? formatNumericValue(subtotal, userCurrency)
                                         : "---"}
                                 </span>
                             </div>
@@ -594,7 +595,10 @@ const AddInvestmentModal = ({
                                     <span className="font-medium text-muted-dark">
                                         {assetCurrencySubtotal > 0 &&
                                         assetCurrency
-                                            ? `${assetCurrencySubtotal.toFixed(2)} (${assetCurrency})`
+                                            ? formatNumericValue(
+                                                  assetCurrencySubtotal,
+                                                  assetCurrency,
+                                              )
                                             : "---"}
                                     </span>
                                 </div>
@@ -605,7 +609,7 @@ const AddInvestmentModal = ({
                                         Fee
                                     </span>
                                     <span className="font-medium text-muted-dark">
-                                        {fee.toFixed(2)} {userCurrency}
+                                        {formatNumericValue(fee, userCurrency)}
                                     </span>
                                 </div>
                             ) : null}
@@ -616,7 +620,7 @@ const AddInvestmentModal = ({
                             </span>
                             <span className="font-medium text-muted-darker">
                                 {total > 0 && userCurrency
-                                    ? `${total.toFixed(2)} (${userCurrency})`
+                                    ? formatNumericValue(total, userCurrency)
                                     : "---"}
                             </span>
                         </div>

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/add-investment-schema.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddInvestment/add-investment-schema.ts
@@ -44,7 +44,11 @@ export const addInvestmentSchema = zod.object({
         (value) => {
             const numberValue = parseFloat(value);
 
-            return !isNaN(numberValue) && numberValue >= 0;
+            if (value === "") {
+                return true; // Treat an empty input as valid
+            } else {
+                return !isNaN(numberValue) && numberValue >= 0;
+            }
         },
         { error: "Fee should be a number greater than or equal to 0" },
     ),

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddTrade/AddTradeModal.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddTrade/AddTradeModal.tsx
@@ -26,6 +26,7 @@ import { addTradeSchema, AddTradeSchema } from "./add-trade-schema";
 import { Field, FieldLabel } from "@/app/components/ui/field";
 import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
 import { useRouter } from "next/navigation";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
 
 export interface SelectedAsset {
     id: number;
@@ -49,7 +50,7 @@ const defaultValues: AddTradeSchema = {
     tradeDate: "",
     pricePerShare: "",
     currencyConversionRate: "1",
-    fee: "0",
+    fee: "",
     total: 0,
     assetCurrencyTotal: 0,
 };
@@ -480,7 +481,10 @@ const AddTradeModal = ({
                                 </span>
                                 <span className="font-medium text-muted-dark">
                                     {subtotal > 0 && userCurrency
-                                        ? `${subtotal.toFixed(2)} (${userCurrency})`
+                                        ? formatNumericValue(
+                                              subtotal,
+                                              userCurrency,
+                                          )
                                         : "---"}
                                 </span>
                             </div>
@@ -493,7 +497,10 @@ const AddTradeModal = ({
                                     <span className="font-medium text-muted-dark">
                                         {assetCurrencySubtotal > 0 &&
                                         assetCurrency
-                                            ? `${assetCurrencySubtotal.toFixed(2)} (${assetCurrency})`
+                                            ? formatNumericValue(
+                                                  assetCurrencySubtotal,
+                                                  assetCurrency,
+                                              )
                                             : "---"}
                                     </span>
                                 </div>
@@ -504,7 +511,7 @@ const AddTradeModal = ({
                                         Fee
                                     </span>
                                     <span className="font-medium text-muted-dark">
-                                        {fee.toFixed(2)} {userCurrency}
+                                        {formatNumericValue(fee, userCurrency)}
                                     </span>
                                 </div>
                             ) : null}
@@ -516,7 +523,7 @@ const AddTradeModal = ({
                             </span>
                             <span className="font-medium text-muted-darker">
                                 {total > 0 && userCurrency
-                                    ? `${total.toFixed(2)} (${userCurrency})`
+                                    ? formatNumericValue(total, userCurrency)
                                     : "---"}
                             </span>
                         </div>

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddTrade/add-trade-schema.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/AddTrade/add-trade-schema.ts
@@ -47,7 +47,11 @@ export const addTradeSchema = zod.object({
         (value) => {
             const numberValue = parseFloat(value);
 
-            return !isNaN(numberValue) && numberValue >= 0;
+            if (value === "") {
+                return true; // Treat an empty input as valid
+            } else {
+                return !isNaN(numberValue) && numberValue >= 0;
+            }
         },
         { error: "Fee should be a number greater than or equal to 0" },
     ),

--- a/apps/ui/stratify-ui/app/components/Form/TextInput.tsx
+++ b/apps/ui/stratify-ui/app/components/Form/TextInput.tsx
@@ -38,6 +38,7 @@ const TextInput = ({
             <FieldLabel htmlFor={id}>{label}</FieldLabel>
             <Input
                 id={id}
+                data-testid={dataTestId ? `${dataTestId}-input` : undefined}
                 placeholder={placeholder}
                 value={defaultValue ? defaultValue : field.state.value}
                 onChange={(e) => field.handleChange(e.target.value)}

--- a/apps/ui/stratify-ui/messages/en/messages.d.json.ts
+++ b/apps/ui/stratify-ui/messages/en/messages.d.json.ts
@@ -45,7 +45,7 @@ declare const messages: {
         },
         "goalProgression": {
             "title": "Goal Progression",
-            "goalNotSet": "No goal set",
+            "goalNotSet": "Goal not set",
             "set": "Set",
             "edit": "Edit",
             "goalSuccessfullyMet": "Your goal of {targetValue, number} ({userCurrency}) has been reached!",


### PR DESCRIPTION
## Stratify UI
- Fix number inputs in compounding and cost-averaging simulator forms so they are empty strings by default
- Change fee field in add trade and add investment modals to default to empty string instead of 0 and pass validation as an empty string (blank is treated as 0)
- Format subtotal, asset currency subtotal, fee and total values in add trade and add investment modals to display numeric values correctly