### PR TITLE
Ab#446 fix goal progression card

### DIFF
--- a/.changeset/big-wasps-repeat.md
+++ b/.changeset/big-wasps-repeat.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+Fix goal not being visible when there is no total value (user has no portfolio or investments)

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/GoalProgressionCard/GoalProgressionCard.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/GoalProgressionCard/GoalProgressionCard.tsx
@@ -81,9 +81,11 @@ const GoalProgressionCard = ({
                             )}
                         </div>
                     </div>
-                ) : totalValue && targetValue ? (
+                ) : targetValue ? (
                     <div className="flex flex-col gap-y-2.5">
-                        <Progress value={(totalValue / targetValue) * 100} />
+                        <Progress
+                            value={((totalValue ?? 0) / targetValue) * 100}
+                        />
                         <div className="flex flex-row justify-between text-lg leading-5 text-secondary-base">
                             <span>{"0"}</span>
                             <span>


### PR DESCRIPTION
- Fix goal not being visible when there is no total value (user has no portfolio or investments)