### PR TITLE
Fix current portfolio value

### DIFF
--- a/.changeset/fancy-papers-notice.md
+++ b/.changeset/fancy-papers-notice.md
@@ -1,0 +1,8 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+- Display total value from portfolio metrics data as current portfolio value instead of the latest value in the portfolio value history
+- Fix loading spinner not appearing when logging in
+- Fix goal not appearing after setting it for the first time
+- Add gap between current holdings and add to portfolio cards on the asset details page when loading

--- a/apps/ui/stratify-ui/app/(screens)/(auth)/login/LoginForm.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/(auth)/login/LoginForm.tsx
@@ -18,6 +18,7 @@ const loginFormOptions = formOptions({
 
 const LoginForm = () => {
     const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
+    const [isPending, setIsPending] = useState(false);
 
     const authClient = useAuthClient();
     const { push } = useRouter();
@@ -36,8 +37,10 @@ const LoginForm = () => {
                 setIsSubmitDisabled(false);
             },
         },
-        onSubmit: async ({ value }) =>
-            await handleLogin(value, authClient, push),
+        onSubmit: async ({ value }) => {
+            setIsPending(true);
+            await handleLogin(value, authClient, push, setIsPending);
+        },
         onSubmitInvalid: () => {
             toast.error("Login failed. Please check the form for errors.");
             setIsSubmitDisabled(true);

--- a/apps/ui/stratify-ui/app/(screens)/(auth)/login/handle-login.test.ts
+++ b/apps/ui/stratify-ui/app/(screens)/(auth)/login/handle-login.test.ts
@@ -41,6 +41,8 @@ const mockAuthClient = {
     },
 } as unknown as AuthClient;
 
+const mockSetIsPending = vi.fn();
+
 vi.mock("@/lib/auth/auth", () => ({
     useAuthClient: () => mockAuthClient,
 }));
@@ -51,7 +53,12 @@ describe("handleLogin", () => {
     });
 
     const executeLogin = async (values: LoginFormValues) => {
-        await handleLogin(values, mockAuthClient, mockRouterPush);
+        await handleLogin(
+            values,
+            mockAuthClient,
+            mockRouterPush,
+            mockSetIsPending,
+        );
     };
 
     it("AB#153 - should handle login with username successfully", async () => {
@@ -76,6 +83,7 @@ describe("handleLogin", () => {
         });
 
         expect(mockStoreToken).toHaveBeenCalledWith("valid-token");
+        expect(mockSetIsPending).toHaveBeenCalledWith(false);
         expect(mockRouterPush).toHaveBeenCalledWith("/app/dashboard");
     });
 
@@ -102,6 +110,7 @@ describe("handleLogin", () => {
 
         expect(mockStoreToken).toHaveBeenCalledWith("valid-token");
         expect(mockRouterPush).toHaveBeenCalledWith("/app/dashboard");
+        expect(mockSetIsPending).toHaveBeenCalledWith(false);
     });
 
     it("should handle login failure correctly (error code specified)", async () => {
@@ -133,6 +142,7 @@ describe("handleLogin", () => {
             "Invalid username or password.",
         );
         expect(mockRouterPush).not.toHaveBeenCalled();
+        expect(mockSetIsPending).toHaveBeenCalledWith(false);
     });
 
     it("should handle login failure correctly (no error code)", async () => {
@@ -158,6 +168,7 @@ describe("handleLogin", () => {
             "Login failed. Please try again.",
         );
         expect(mockRouterPush).not.toHaveBeenCalled();
+        expect(mockSetIsPending).toHaveBeenCalledWith(false);
     });
 
     it("should handle unexpected errors correctly", async () => {
@@ -182,5 +193,6 @@ describe("handleLogin", () => {
         );
 
         expect(mockRouterPush).not.toHaveBeenCalled();
+        expect(mockSetIsPending).toHaveBeenCalledWith(false);
     });
 });

--- a/apps/ui/stratify-ui/app/(screens)/(auth)/login/handle-login.ts
+++ b/apps/ui/stratify-ui/app/(screens)/(auth)/login/handle-login.ts
@@ -4,11 +4,13 @@ import { storeAuthToken } from "@/lib/auth/store-auth-token";
 import { getAuthErrorMessage } from "@/lib/auth/authErrorCodes";
 import type { LoginFormValues } from "./login-schema";
 import type { AuthClient } from "@/lib/auth/auth";
+import { Dispatch, SetStateAction } from "react";
 
 export const handleLogin = async (
     value: LoginFormValues,
     authClient: AuthClient,
     push: ReturnType<typeof useRouter>["push"],
+    setIsPending: Dispatch<SetStateAction<boolean>>,
 ) => {
     const isEmail = value.emailOrUsername.includes("@");
 
@@ -26,21 +28,23 @@ export const handleLogin = async (
               });
 
         if (data?.token) {
+            setIsPending(false);
             await storeAuthToken(data.token);
             return push("/app/dashboard");
         }
 
         if (error?.code) {
             const errorMessage = getAuthErrorMessage(error.code);
-
+            setIsPending(false);
             return errorMessage
                 ? toast.error(errorMessage)
                 : toast.error("Login failed. Please try again.");
         } else {
+            setIsPending(false);
             return toast.error("Login failed. Please try again.");
         }
     } catch (error) {
-        console.error("Login error:", error);
+        setIsPending(false);
         return toast.error("Login failed. Please try again.");
     }
 };

--- a/apps/ui/stratify-ui/app/(screens)/(auth)/sign-up/SignUpForm.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/(auth)/sign-up/SignUpForm.tsx
@@ -193,7 +193,7 @@ const SignUpForm = () => {
                                         }}
                                     />
                                     <CommandList
-                                        className={`absolute w-auto mt-11 p-1 gap-y-1.5 max-h-[150px] bg-white border border-secondary-dark rounded-md ${isCurrencyListOpen ? "" : "hidden"}`}
+                                        className={`absolute w-auto mt-11 p-1 gap-y-1.5 max-h-37.5 bg-white border border-secondary-dark rounded-md ${isCurrencyListOpen ? "" : "hidden"}`}
                                     >
                                         {isLoading ? (
                                             <div className="flex flex-col gap-2">

--- a/apps/ui/stratify-ui/app/(screens)/app/assets/[assetId]/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/assets/[assetId]/page.tsx
@@ -86,7 +86,7 @@ export default function AssetPage() {
                         />
                     </div>
                 </div>
-                <div className="flex flex-col justify-between ml-10 w-1/4">
+                <div className="flex flex-col justify-between ml-10 w-1/4 gap-y-5">
                     <CurrentHoldingsCard
                         assetHoldings={assetHoldings ?? []}
                         assetCurrency={assetDetails?.assetCurrency ?? ""}

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/GoalProgressionCard/useGoal.ts
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/components/GoalProgressionCard/useGoal.ts
@@ -26,9 +26,11 @@ export const useGoal = () => {
         refetch,
     } = useQuery({
         queryKey: ["goal"],
+        enabled: !cachedGoal,
         queryFn: async () => {
             try {
                 const response = await client.GET("/goal");
+                setIsGoalNotFoundError(false);
 
                 return response.data?.data;
             } catch (error) {

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueChart.test.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueChart.test.tsx
@@ -5,6 +5,7 @@ import { screen } from "@testing-library/react";
 import MockSessionProvider from "@/app/tests/_mocks/MockSessionProvider";
 import { PortfolioValueHistory } from "./usePortfolioValueHistory";
 import { TooltipProvider } from "@/app/components/ui/tooltip";
+import { mockMetricsData } from "../PortfolioMetrics/_mocks/mockMetricsData";
 
 const mockPortfolioValueHistoryData = [
     {
@@ -36,6 +37,17 @@ vi.mock("./usePortfolioValueHistory", () => ({
     usePortfolioValueHistory: () => mockUsePortfolioValueHistory(),
 }));
 
+const defaultPortfolioMetricsHookReturnValues = {
+    data: mockMetricsData,
+    isLoading: false,
+};
+
+const mockUsePortfolioMetrics = vi.fn();
+
+vi.mock("../PortfolioMetrics/usePortfolioMetrics", () => ({
+    usePortfolioMetrics: () => mockUsePortfolioMetrics(),
+}));
+
 describe("PortfolioValueChart", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -54,6 +66,9 @@ describe("PortfolioValueChart", () => {
 
     it("should render the component successfully", () => {
         mockUsePortfolioValueHistory.mockReturnValue(defaultHookReturnValues);
+        mockUsePortfolioMetrics.mockReturnValue(
+            defaultPortfolioMetricsHookReturnValues,
+        );
 
         renderComponent();
 
@@ -61,17 +76,21 @@ describe("PortfolioValueChart", () => {
 
         expect(screen.getByText("Portfolio value")).toBeInTheDocument();
         expect(selectedDateRange).toHaveTextContent("Last 30 days");
-        expect(screen.getByText("11,000")).toBeInTheDocument();
+        expect(screen.getByText("100,000")).toBeInTheDocument();
 
         expect(screen.getByText("(GBP)")).toBeInTheDocument();
 
-        expect(screen.getByText("+10.00%")).toBeInTheDocument();
+        expect(screen.getByText("+900%")).toBeInTheDocument();
         expect(screen.getByText("in the past thirty days")).toBeInTheDocument();
     });
 
     it("should render the loading state when data is loading", () => {
         mockUsePortfolioValueHistory.mockReturnValue({
             ...defaultHookReturnValues,
+            isLoading: true,
+        });
+        mockUsePortfolioMetrics.mockReturnValue({
+            ...defaultPortfolioMetricsHookReturnValues,
             isLoading: true,
         });
 
@@ -86,6 +105,10 @@ describe("PortfolioValueChart", () => {
         mockUsePortfolioValueHistory.mockReturnValue({
             ...defaultHookReturnValues,
             data: [],
+        });
+        mockUsePortfolioMetrics.mockReturnValue({
+            ...defaultPortfolioMetricsHookReturnValues,
+            data: {},
         });
 
         renderComponent();

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueChart.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+import { Area, AreaChart, XAxis } from "recharts";
 import { ChartContainer, ChartTooltip } from "@/app/components/ui/chart";
 import { useSessionContext } from "../../../SessionProvider";
 import { usePortfolioValueHistory } from "./usePortfolioValueHistory";
@@ -10,6 +10,7 @@ import PortfolioValueDetails from "./PortfolioValueDetails";
 import PortfolioValueChartSkeleton from "./PortfolioValueChartSkeleton";
 import { placeholderChartData } from "./placeholderChartData";
 import { formatNumericValue } from "@/app/utils/formatNumericValue";
+import { usePortfolioMetrics } from "../PortfolioMetrics/usePortfolioMetrics";
 
 interface ChartTooltipProps {
     active?: boolean;
@@ -55,10 +56,15 @@ const PortfolioValueChart = ({ portfolioId }: PortfolioValueChartProps) => {
     const [selectedDateRange, setSelectedDateRange] =
         useState<DateRange>("30d");
 
-    const { data, isLoading } = usePortfolioValueHistory(portfolioId);
+    const { data: portfolioValueData, isLoading: isPortfolioValueLoading } =
+        usePortfolioValueHistory(portfolioId);
+    const { data: portfolioMetricsData, isLoading: isPortfolioMetricsLoading } =
+        usePortfolioMetrics(portfolioId);
+
+    const isLoading = isPortfolioValueLoading || isPortfolioMetricsLoading;
 
     const filteredData =
-        data?.filter((value) => {
+        portfolioValueData?.filter((value) => {
             const valueDate = new Date(value.date).toISOString().split("T")[0];
             const startDate = new Date();
 
@@ -92,6 +98,7 @@ const PortfolioValueChart = ({ portfolioId }: PortfolioValueChartProps) => {
         <div className="flex flex-col w-full font-sans">
             <PortfolioValueDetails
                 filteredData={filteredData}
+                currentValue={portfolioMetricsData?.totalValue}
                 currency={currency!}
                 selectedDateRange={selectedDateRange}
                 setSelectedDateRange={setSelectedDateRange}
@@ -108,7 +115,14 @@ const PortfolioValueChart = ({ portfolioId }: PortfolioValueChartProps) => {
                 <AreaChart
                     data={
                         filteredData.length > 0
-                            ? filteredData
+                            ? [
+                                  ...filteredData,
+                                  {
+                                      date: new Date().toISOString(),
+                                      portfolioValue:
+                                          portfolioMetricsData?.totalValue ?? 0,
+                                  },
+                              ]
                             : placeholderChartData
                     }
                 >
@@ -140,7 +154,6 @@ const PortfolioValueChart = ({ portfolioId }: PortfolioValueChartProps) => {
                             />
                         </linearGradient>
                     </defs>
-                    <CartesianGrid vertical={false} />
                     <XAxis
                         dataKey="date"
                         hide={filteredData.length === 0}

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueDetails.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/components/PortfolioValueChart/PortfolioValueDetails.tsx
@@ -14,6 +14,8 @@ import {
     TooltipTrigger,
 } from "@/app/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { formatNumericValue } from "@/app/utils/formatNumericValue";
+import { useTranslations } from "next-intl";
 
 const changeInDateRangeLabel = {
     "7d": "in the past seven days",
@@ -25,6 +27,7 @@ const changeInDateRangeLabel = {
 
 interface PortfolioValueDetailsProps {
     filteredData: PortfolioValueHistory[];
+    currentValue?: number;
     selectedDateRange: DateRange;
     setSelectedDateRange: Dispatch<SetStateAction<DateRange>>;
     currency?: string;
@@ -32,27 +35,23 @@ interface PortfolioValueDetailsProps {
 
 const PortfolioValueDetails = ({
     filteredData,
+    currentValue,
     currency,
     selectedDateRange,
     setSelectedDateRange,
 }: PortfolioValueDetailsProps) => {
+    const translate = useTranslations();
     const firstValue =
         filteredData.length > 0 ? filteredData[0].portfolioValue : null;
 
-    const latestValue =
-        filteredData.length > 0
-            ? filteredData[filteredData.length - 1].portfolioValue
-            : null;
-
-    const portfolioValueChange =
-        firstValue && latestValue
-            ? ((latestValue - firstValue) / firstValue) * 100
+    const portfolioValueChangePercentage =
+        firstValue && currentValue
+            ? ((currentValue - firstValue) / firstValue) * 100
             : null;
 
     const isPositiveChange =
-        portfolioValueChange !== null && portfolioValueChange >= 0.01;
-
-    const sign = isPositiveChange ? "+" : "";
+        portfolioValueChangePercentage !== null &&
+        portfolioValueChangePercentage >= 0.01;
 
     return (
         <div className="flex flex-col">
@@ -83,12 +82,12 @@ const PortfolioValueDetails = ({
                 />
             </div>
             <div className="flex flex-row text-muted-base text-3xl font-semibold">
-                {latestValue !== null ? (
+                {currentValue ? (
                     <>
-                        <div>{latestValue.toLocaleString()}</div>
-                        <div className="text-base ml-1 mt-2 content-end">
-                            {currency ? `(${currency})` : null}
-                        </div>
+                        <span>{formatNumericValue(currentValue)}</span>
+                        <span className="text-base ml-1 mt-2 content-end">
+                            {currency ? `(${currency})` : "---"}
+                        </span>
                     </>
                 ) : (
                     <div>No data available</div>
@@ -103,15 +102,20 @@ const PortfolioValueDetails = ({
                         : "text-negative-base",
                 )}
             >
-                {portfolioValueChange !== null ? (
+                {portfolioValueChangePercentage !== null ? (
                     <div className="flex flex-row items-center transition-all">
                         {isPositiveChange ? (
                             <ChartColumnIncreasing size={22} />
                         ) : (
                             <ChartColumnDecreasing size={22} />
                         )}
-                        {sign}
-                        {portfolioValueChange.toFixed(2)}%
+                        {portfolioValueChangePercentage > 0
+                            ? translate("Generic.positivePercentage", {
+                                  percentage: portfolioValueChangePercentage,
+                              })
+                            : translate("Generic.percentage", {
+                                  percentage: portfolioValueChangePercentage,
+                              })}
                         <span className="ml-1 text-sm">
                             {changeInDateRangeLabel[selectedDateRange]}
                         </span>


### PR DESCRIPTION
- Display total value from portfolio metrics data as current portfolio value instead of the latest value in the portfolio value history
- Fix loading spinner not appearing when logging in
- Fix goal not appearing after setting it for the first time
- Add gap between current holdings and add to portfolio cards on the asset details page when loading