### PR TITLE
Ab#447 & Ab#448 & Ab#449 - Fix displaying issues on Chrome and enable scrolling on pages

### DIFF
--- a/.changeset/grumpy-clouds-share.md
+++ b/.changeset/grumpy-clouds-share.md
@@ -1,0 +1,8 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+- Fix displaying of page titles on all screens by ensuring they span the full width and align to the left instead of being centered
+- Fix displaying of market data tabs and data table on markets page by ensuring they span the full width
+- Allow for scrolling on all pages by removing the fixed height and overflow hidden on the main container and in the layout
+- Add more width to the simulator forms on the learn pages so that the labels do not wrap to multiple lines

--- a/apps/ui/stratify-ui/app/(screens)/app/dashboard/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/dashboard/page.tsx
@@ -31,8 +31,8 @@ export default function DashboardPage() {
     const isLoading = isOverviewLoading || isGoalLoading;
 
     return (
-        <div className="items-center justify-items-center h-full px-10">
-            <div className="font-sans text-5xl text-primary-base font-semibold leading-14">
+        <div className="min-h-screen px-10">
+            <div className="font-sans text-5xl text-primary-base font-semibold leading-14 w-full text-left">
                 {translate("title")}
             </div>
             <div className="mt-8 w-full">

--- a/apps/ui/stratify-ui/app/(screens)/app/layout.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/layout.tsx
@@ -29,14 +29,8 @@ export default function AppLayout({ children }: AuthLayoutProps) {
                     <PublicEnv />
                     <Providers>
                         <SessionProvider>
-                            <div className="h-screen flex flex-col">
-                                <AppNavbar />
-                                <TooltipProvider>
-                                    <div className="flex-1 overflow-hidden">
-                                        {children}
-                                    </div>
-                                </TooltipProvider>
-                            </div>
+                            <AppNavbar />
+                            <TooltipProvider>{children}</TooltipProvider>
                         </SessionProvider>
                         <Toaster richColors />
                     </Providers>

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingSimulatorForm.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/CompoundingSimulatorForm.tsx
@@ -122,7 +122,7 @@ const CompoundingSimulatorForm = ({
                 e.preventDefault();
                 form.handleSubmit();
             }}
-            className="bg-primary-lightest rounded-xl border border-primary-light py-2 px-3 flex flex-col gap-y-3"
+            className="bg-primary-lightest rounded-xl border border-primary-light py-2 px-3 flex flex-col gap-y-3 w-1/3"
         >
             <form.AppField name="assetName">
                 {(field) => {

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/compounding/page.tsx
@@ -5,8 +5,8 @@ import CompoundingSimulator from "./CompoundingSimulator";
 
 export default function CompoundingPage() {
     return (
-        <div className="items-center justify-items-center font-sans h-full px-10">
-            <div className="text-5xl leading-14 text-primary-base font-semibold">
+        <div className="font-sans min-h-screen px-10">
+            <div className="text-5xl leading-14 text-primary-base font-semibold w-full text-left">
                 Compounding
             </div>
             <div className="flex flex-col mt-4 gap-y-5">

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingSimulatorForm.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/CostAveragingSimulatorForm.tsx
@@ -184,7 +184,7 @@ const CostAveragingSimulatorForm = ({
                 e.preventDefault();
                 form.handleSubmit();
             }}
-            className="bg-primary-lightest rounded-xl border border-primary-light py-2 px-3 flex flex-col gap-y-3"
+            className="bg-primary-lightest rounded-xl border border-primary-light py-2 px-3 flex flex-col gap-y-3 w-1/3"
         >
             <form.AppField name="assetName">
                 {(field) => {

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/cost-averaging/page.tsx
@@ -5,8 +5,8 @@ import CostAveragingSimulator from "./CostAveragingSimulator";
 
 export default function CostAveragingPage() {
     return (
-        <div className="items-center justify-items-center font-sans h-full px-10">
-            <div className="text-5xl leading-14 text-primary-base font-semibold">
+        <div className="font-sans min-h-screen px-10">
+            <div className="text-5xl leading-14 text-primary-base font-semibold w-full text-left">
                 Cost Averaging
             </div>
             <div className="flex flex-col mt-4 gap-y-5">

--- a/apps/ui/stratify-ui/app/(screens)/app/learn/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/learn/page.tsx
@@ -4,8 +4,8 @@ import LearnCard from "./components/LearnCard";
 
 export default function LearnPage() {
     return (
-        <div className="items-center justify-items-center h-full px-10">
-            <div className="font-sans text-5xl text-primary-base font-semibold leading-14">
+        <div className="min-h-screen px-10">
+            <div className="font-sans text-5xl text-primary-base font-semibold leading-14 w-full text-left">
                 Learn
             </div>
 

--- a/apps/ui/stratify-ui/app/(screens)/app/markets/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/markets/page.tsx
@@ -11,12 +11,12 @@ export default function MarketsPage() {
     const [selectedTab, setSelectedTab] = useState<MarketDataTab>("topGainers");
 
     return (
-        <div className="items-center justify-items-center h-full px-10">
-            <div className="font-sans text-5xl text-primary-base font-semibold">
+        <div className="min-h-screen px-10 pb-10">
+            <div className="font-sans text-5xl text-primary-base font-semibold w-full text-left">
                 Markets
             </div>
 
-            <div className="flex items-center justify-between mt-4">
+            <div className="flex flex-row items-center justify-between mt-4">
                 <MarketDataTabs
                     selectedTab={selectedTab}
                     setSelectedTab={setSelectedTab}

--- a/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
+++ b/apps/ui/stratify-ui/app/(screens)/app/portfolios/page.tsx
@@ -33,8 +33,8 @@ export default function PortfoliosPage() {
     }, [data, selectedPortfolioId]);
 
     return (
-        <div className="h-full px-10">
-            <div className="font-sans text-5xl text-primary-base font-semibold">
+        <div className="min-h-screen px-10">
+            <div className="font-sans text-5xl text-primary-base font-semibold w-full text-left">
                 Portfolios
             </div>
             <div className="flex flex-row w-full mt-4">


### PR DESCRIPTION
## Stratify UI
- Fix displaying of page titles on all screens by ensuring they span the full width and align to the left instead of being centered
- Fix displaying of market data tabs and data table on markets page by ensuring they span the full width
- Allow for scrolling on all pages by removing the fixed height and overflow hidden on the main container and in the layout
- Add more width to the simulator forms on the learn pages so that the labels do not wrap to multiple lines