### PR TITLE
Ab#450 - Make Stratify logo/text in navbar clickable to navigate to homepage or dashboard

### DIFF
--- a/.changeset/cold-snakes-wish.md
+++ b/.changeset/cold-snakes-wish.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-ui": patch
+---
+
+Use Link component in AppNavbar and PublicNavbar to navigate to the dashboard or homepage

--- a/apps/ui/stratify-ui/app/components/(app)/AppNavbar.test.tsx
+++ b/apps/ui/stratify-ui/app/components/(app)/AppNavbar.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe } from "vitest";
 import AppNavbar from "./AppNavbar";
 import MockSessionProvider from "@/app/tests/_mocks/MockSessionProvider";
 import userEvent from "@testing-library/user-event";
+import { mockNextLink } from "@/app/tests/_mocks/mockNextLink";
 
 const user = userEvent.setup();
 
@@ -11,6 +12,8 @@ const user = userEvent.setup();
 vi.mock("next/image", () => ({
     default: (props: { alt?: string }) => <img alt={props.alt} />,
 }));
+
+mockNextLink();
 
 describe("AppNavbar", () => {
     beforeEach(() => {

--- a/apps/ui/stratify-ui/app/components/(app)/AppNavbar.tsx
+++ b/apps/ui/stratify-ui/app/components/(app)/AppNavbar.tsx
@@ -19,12 +19,15 @@ const navLinks = [
 const AppNavbar = () => {
     return (
         <nav className="sticky top-0 bg-background-light flex flex-row justify-between px-10 py-6 items-center">
-            <div className="flex-1 justify-start flex flex-row gap-x-2 py-2">
+            <Link
+                href="/app/dashboard"
+                className="flex-1 justify-start flex flex-row gap-x-2 py-2"
+            >
                 <StratifyIcon width={40} height={40} />
                 <div className="font-sans font-semibold text-primary-base text-4xl">
                     Stratify
                 </div>
-            </div>
+            </Link>
             <div className="font-sans bg-sidebar-light rounded-full px-10 py-4 w-fit flex flex-row gap-x-10 justify-self-center">
                 {navLinks.map((link) => (
                     <Link

--- a/apps/ui/stratify-ui/app/components/(public)/PublicNavbar/PublicNavbar.tsx
+++ b/apps/ui/stratify-ui/app/components/(public)/PublicNavbar/PublicNavbar.tsx
@@ -21,12 +21,15 @@ interface PublicNavbarProps {
 const PublicNavbar = ({ showLoginSignUpButtons = true }: PublicNavbarProps) => {
     return (
         <nav className="sticky top-0 bg-background-light flex flex-row justify-between px-16 py-6 items-center">
-            <div className="flex-1 justify-start flex flex-row gap-x-2 py-2">
+            <Link
+                href="/"
+                className="flex-1 justify-start flex flex-row gap-x-2 py-2"
+            >
                 <StratifyIcon width={40} height={40} />
                 <div className="font-sans font-semibold text-primary-base text-4xl">
                     Stratify
                 </div>
-            </div>
+            </Link>
             <div className="font-sans bg-sidebar-light rounded-full px-10 py-4 w-fit flex flex-row gap-x-10 justify-self-center">
                 {navLinks.map((link) => (
                     <Link


### PR DESCRIPTION
- Use Link component in AppNavbar and PublicNavbar to navigate to the dashboard or homepage