### PR TITLE
Ab#451 - Fix calculation of total value of all portfolios

### DIFF
--- a/.changeset/fancy-clubs-relate.md
+++ b/.changeset/fancy-clubs-relate.md
@@ -1,0 +1,5 @@
+---
+"@stratify/stratify-api": patch
+---
+
+Fix calculation of the total value of all portfolios by summing up the investments in all portfolios instead of summing up the value of each portfolio (used in the portfolio value history endpoint)

--- a/apps/api/stratify-api/src/routes/portfolios/overview/overview.get.ts
+++ b/apps/api/stratify-api/src/routes/portfolios/overview/overview.get.ts
@@ -105,19 +105,17 @@ const retrieveOverviewDetails = async (portfolioIds: number[]) => {
         (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
     );
 
-    const totalValue = sortedValueHistory.length
-        ? sortedValueHistory[sortedValueHistory.length - 1].portfolioValue
-        : 0;
-
-    const { overallReturn, totalBuyAmount } = investments.reduce(
+    const { totalValue, overallReturn, totalBuyAmount } = investments.reduce(
         (sum, investment) => {
             return {
+                totalValue: (sum.totalValue += investment.currentValue),
                 overallReturn: (sum.overallReturn += investment.currentReturn),
                 totalBuyAmount: (sum.totalBuyAmount +=
                     investment.totalBuyAmount),
             };
         },
         {
+            totalValue: 0,
             overallReturn: 0,
             totalBuyAmount: 0,
         },


### PR DESCRIPTION
## Stratify API
- Fix calculation of the total value of all portfolios by summing up the investments in all portfolios instead of summing up the value of each portfolio (used in the portfolio value history endpoint)